### PR TITLE
feat: 2.0.0

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -1,1 +1,1 @@
-/home/vacation/Desktop/interface/dotfiles/.cspell.config.yml
+/Users/thom.ribeiro/Desktop/interface/dotfiles/.cspell.config.yml

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -1,1 +1,1 @@
-/Users/thom.ribeiro/Desktop/interface/dotfiles/.cspell.config.yml
+/home/vacation/Desktop/interface/dotfiles/.cspell.config.yml

--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -1,1 +1,0 @@
-/home/vacation/Desktop/interface/dotfiles/.cspell.config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/jailmcphttp
 dotfiles/**/.uuid
 **/.DS_Store
 dotfiles/.config/jj/repos/*
+.cspell.config.yml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ bin/t0filer
 bin/ollama
 bin/forex
 bin/presentvalue
+bin/jail-mcp
+bin/jailmcphttp
 dotfiles/**/.uuid
 **/.DS_Store
 dotfiles/.config/jj/repos/*

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golang 1.26.1
+nodejs 25.8.1

--- a/bin/download-youtube-id
+++ b/bin/download-youtube-id
@@ -91,7 +91,7 @@ download() {
 
   # downloading big videos can max out /tmp
   # ejs:github related to automated captcha challenges using deno
-  if ! yt-dlp -f "$format_id" "$vid_id" --output "${prefix}%(title)s-%(release_date)s.%(ext)s" --remote-components ejs:github --paths "temp:/plex/tmp"; then
+  if ! yt-dlp -f "$format_id" --output "${prefix}%(title)s-%(release_date)s.%(ext)s" --remote-components ejs:github --paths "temp:/plex/tmp" -- "$vid_id"; then
     fatal "$LINENO" "yt-dlp error"
   fi
 }
@@ -187,7 +187,7 @@ validate_input
 validate_plex_perms
 prepare_temp
 
-yt-dlp "$vid_id" --list-formats --remote-components ejs:github --paths "temp:/plex/tmp"
+yt-dlp --list-formats --remote-components ejs:github --paths "temp:/plex/tmp" -- "$vid_id"
 
 prompt_audio_format
 prompt_video_format

--- a/bin/lazy-git
+++ b/bin/lazy-git
@@ -85,6 +85,7 @@ commit() {
     fatal $LINENO "usage: lg <type> <scope> <commit subject>"
   fi
 
+  subject="${subject,}"
   local commit_msg="$type($scope): $subject"
   if [[ "$scope" =~ ^.$ ]]; then
     commit_msg="$type: $subject"

--- a/bin/lazy-jujutsu
+++ b/bin/lazy-jujutsu
@@ -56,6 +56,7 @@ commit() {
     fatal $LINENO "usage: lg <type> <scope> <commit subject>"
   fi
 
+  subject="${subject,}"
   local commit_msg="$type($scope): $subject"
 
   if [[ "$scope" =~ ^.$ ]]; then

--- a/bin/ollama-unload
+++ b/bin/ollama-unload
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Check if Ollama is running by attempting to hit the API
+if ! curl -s http://localhost:11434/api/ps >/dev/null 2>&1; then
+  echo "INFO: Ollama is not running." >&2
+  exit 1
+fi
+
+# Fetch the list of loaded models via the API
+models=$(curl -s http://localhost:11434/api/ps | jq -r '.models[].name')
+
+if [ -z "$models" ]; then
+  echo "INFO: No models currently loaded in Ollama." >&2
+  exit 0
+fi
+
+for model in $models; do
+  echo "INFO: Unloading $model..." >&2
+  # Using an empty prompt to trigger the unload via the generate endpoint
+  curl -s -X POST http://localhost:11434/api/generate \
+    -d "{\"model\": \"$model\", \"prompt\": \"\", \"keep_alive\": 0}" >/dev/null
+done
+
+# Give the Ollama process and the GPU driver a few seconds to actually
+# finish the memory release before the system proceeds to sleep.
+echo "INFO: Waiting for models to release VRAM..." >&2
+sleep 3
+
+echo "INFO: All loaded models have been signaled to unload and settling period complete." >&2

--- a/bin/system-up
+++ b/bin/system-up
@@ -213,6 +213,7 @@ mise_install_globals() {
   mise use --global go@latest
   mise use --global yarn@1.22.22
   mise use --global npm@latest
+  mise use --global uv@latest
 
   # reinstall missing npm globals
   local packages=(cspell@latest prettier@latest @commitlint/cli@latest @commitlint/config-conventional@latest)

--- a/bin/system-up
+++ b/bin/system-up
@@ -223,6 +223,12 @@ mise_install_globals() {
   done
 }
 
+# Mise configuration file is sim linked into its /root.
+# Install packages globally for root.
+mise_root_update() {
+  sudo mise install
+}
+
 cleanup_packages() {
   # 19GB of build dependencies of llama.cpp
   yay --remove --recursive --recursive rocm-hip-sdk
@@ -239,6 +245,7 @@ btrfs_check Data2TB Data4TB
 pg_update=$(postgres_up)
 
 mise_install_globals
+mise_root_update
 system_up
 services start postgresql
 refresh_collations

--- a/doc/etc.md
+++ b/doc/etc.md
@@ -1,8 +1,12 @@
 # etc/ — System Configuration
 
 Files here are symlinked (or hardlinked for `fstab`) into `/etc`. Requires root for install.
-Note: all `/etc` symlinks resolve through `/home/vacation/` — root must be able to traverse it. Ensure `chmod o+x /home/vacation` is set, otherwise systemd and other root processes silently fail to read unit files and configs at boot.
+Note: all `/etc` symlinks resolve through `/home/vacation/` — root must be able to traverse it.
+Ensure `chmod o+x /home/vacation` is set, otherwise systemd and other root processes silently fail to read unit files and configs at boot.
 Note: `/etc/fstab` must be a **hardlink**, not a symlink — the kernel reads it before symlinks resolve.
+Note: due to how the system mounts partitions at boot, and how /home/vacation is its own btrfs subvolume mount, files in etc/ might be unavailable at boot, leading to weird bugs.
+The proposed solution for this is to use an install script that copies files to /etc with correct ownership and permissions.
+Git hook into pull and commit, maintain hashes of all files, maybe adjacent to the files themselves but gitignored, and determine if file needs to be reinstalled.
 
 ## Filesystem & Boot
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -1,16 +1,17 @@
 # install — Dotfiles Install Program
 
-A `go run`-able install program at `src/install/`. Replaces t0filer for the `interface` repo.
+A `go run`-able install program at `src/install/`.
+Replaces t0filer for the `interface` repo.
 Processes `install.rc` and applies file operations to the system.
 
 ## Usage
 
 ```bash
-go run ./src/install                        # dry run (default, no changes)
-go run ./src/install -c                     # commit changes
-sudo go run ./src/install -c               # commit changes as root
-go run ./src/install -config path/to/rc    # use a specific config file (default: install.rc)
-go run ./src/install -v                    # print version
+go run ./src/install -commit              # commit changes
+go run ./src/install                      # dry run (default, no changes)
+sudo go run ./src/install -commit         # commit changes as root
+go run ./src/install -config path/to/rc   # use a specific config file (default: install.rc)
+go run ./src/install -v                   # print version
 ```
 
 ## Config file — `install.rc`
@@ -35,17 +36,17 @@ Blank lines are ignored. Lines starting with `#` are comments and are ignored.
 
 ### Actions
 
-| Action    | Args                       | Description                                              |
-| --------- | -------------------------- | -------------------------------------------------------- |
-| `check`   | `binary install-cmd`/line  | Verify binary exists; collect all failures, abort at end |
-| `assert`  | command and hint in pairs  | Run a shell command; collect all failures, abort at end  |
-| `message` | free text, multi-line      | Print a block of text to the user                        |
-| `mkdir`   | one path/line              | Create directory and parents if it does not exist        |
-| `link`    | path pairs                 | Create symlink; source first, link target second         |
-| `copy`    | path pairs                 | Copy file; skipped if target exists and checksums match  |
-| `enable`  | one unit/line              | `systemctl enable --now <unit>`                          |
-| `chmod`   | `mode path`/line           | Apply permission mode to path                            |
-| `reload`  | none                       | `systemctl daemon-reload`                                |
+| Action    | Args                      | Description                                              |
+| --------- | ------------------------- | -------------------------------------------------------- |
+| `check`   | `binary install-cmd`/line | Verify binary exists; collect all failures, abort at end |
+| `assert`  | command and hint in pairs | Run a shell command; collect all failures, abort at end  |
+| `message` | free text, multi-line     | Print a block of text to the user                        |
+| `mkdir`   | one path/line             | Create directory and parents if it does not exist        |
+| `link`    | path pairs                | Create symlink; source first, link target second         |
+| `copy`    | path pairs                | Copy file; skipped if target exists and checksums match  |
+| `enable`  | one unit/line             | `systemctl enable --now <unit>`                          |
+| `chmod`   | `mode path`/line          | Apply permission mode to path                            |
+| `reload`  | none                      | `systemctl daemon-reload`                                |
 
 `$HOME` in paths is expanded to the current user home directory.
 `enable`, `chmod`, and `reload` are Linux-only and implicitly skipped on other systems.
@@ -67,6 +68,7 @@ golangci-lint see https://golangci-lint.run/welcome/install
 ```
 
 Output on failure:
+
 ```
 check: missing binaries
   git           pacman -S git
@@ -178,15 +180,17 @@ in both dry run and commit modes. If validation finds errors, the program exits 
 touching anything. This surfaces all problems upfront rather than failing halfway through.
 
 Validation checks:
+
 - Source file exists
 - Target parent directory exists (or will be created via `mkdir`)
-- For `link`: if target exists, verify it already points to the correct source
+- For `link`: if target exists, verify it is a link and already points to the correct source
 - For `copy`: if target exists, checksum both files; identical = already done
 - For `assert`: line count is even
 
 ### Idempotent
 
 Re-running is safe. Each operation detects its already-complete state and skips:
+
 - `link`: target is already a symlink to the correct source → skip
 - `copy`: target exists and checksums match → skip
 - `mkdir`: directory already exists → skip
@@ -196,6 +200,8 @@ Re-running is safe. Each operation detects its already-complete state and skips:
 ### Broken link cleanup
 
 Before linking, any broken symlink at the target path is removed. A warning is printed.
+If a regular file occupies the path of the link, error
+if a link exists, it must point to the correct target, if not remove and re-create.
 
 ### Directory creation
 
@@ -207,6 +213,13 @@ If a target parent directory does not exist, it is created. A warning is printed
 If an unexpected error occurs during commit (after validation passed), the program exits
 immediately. The next run skips already-completed operations and picks up where it left off.
 
+### etc/
+
+Because of complex boot time filesystem mounting order, and the current layout of /home/vacation as a sub volume, etc/ files should be copied not linked, by user root.
+
+### git hooks
+
+Hooks for commit and pull should re-run install to verify targets of copy and link are still accurate with new source files.
 
 ## Testing
 
@@ -289,6 +302,7 @@ This should not print on Linux.
 ```
 
 Expected outcomes to verify manually:
+
 - Warning printed for missing user declaration at top
 - `check` fails listing the missing binary with its hint, does not abort before checking all
 - `assert` fails listing the failing assertion with its hint, does not abort before checking all

--- a/doc/prompts/chat-work-session-jail.md
+++ b/doc/prompts/chat-work-session-jail.md
@@ -1,7 +1,7 @@
 Call the jail MCP context tool at the start of each session to orient yourself.
+Then run the setup tool on the project path to prepare the environment.
 Use exec_sync for most file tasks (cat, find, grep, sed). This is the only way to interact with project files.
 Use exec_background for slow commands; poll with the status tool. You can do other work while waiting.
-If the project's language isn't installed, run the setup tool on the project path first.
   - Go projects may have private dependencies — run bin/setup, not just go mod download.
 Start by reading AGENTS.md at the project root, then look for docs in .md files under doc/.
 Projects named foo-1, foo-2 are git worktrees of foo — same codebase, different branch.

--- a/doc/prompts/chat-work-session-jail.md
+++ b/doc/prompts/chat-work-session-jail.md
@@ -1,12 +1,3 @@
-
-## claude code
-
-read AGENTS.md at the root first, if it doesn't exist, mention this to user.
-search for project docs in .md files under doc/, fast way to discover the codebase.
-note that PR titles must be conventional commits.
-
-## start a work session in chat
-
 check your jail mcp tools for a context tool, and call it on the project I'll provide.
 exec sync is the tool for most tasks, it's a shell: cat, find, grep, sed.
 for security, this is the only way to interact with project files.
@@ -18,6 +9,6 @@ start here:
 2) if necessary: start the setup tool and while it runs in background, go do some other work.
 Go projects might have private dependencies that won't install unless setup tool is ran (bin/setup normally)
 
-project: 
+project:
 task:
 

--- a/doc/prompts/chat-work-session-jail.md
+++ b/doc/prompts/chat-work-session-jail.md
@@ -1,14 +1,24 @@
-check your jail mcp tools for a context tool, and call it on the project I'll provide.
-exec sync is the tool for most tasks, it's a shell: cat, find, grep, sed.
-for security, this is the only way to interact with project files.
-if the project's programming language isn't installed, call the setup tool on the project path.
-exec background is for slow commands, and multitasking.
-fyi: projects name like foo, foo-1, are just worktrees of foo.
-start here:
-1) read AGENTS.md at the root first, search for project docs in .md files, normally under doc/.
-2) if necessary: start the setup tool and while it runs in background, go do some other work.
-Go projects might have private dependencies that won't install unless setup tool is ran (bin/setup normally)
+Call the jail MCP context tool at the start of each session to orient yourself.
+Use exec_sync for most file tasks (cat, find, grep, sed). This is the only way to interact with project files.
+Use exec_background for slow commands; poll with the status tool. You can do other work while waiting.
+If the project's language isn't installed, run the setup tool on the project path first.
+  - Go projects may have private dependencies — run bin/setup, not just go mod download.
+Start by reading AGENTS.md at the project root, then look for docs in .md files under doc/.
+Projects named foo-1, foo-2 are git worktrees of foo — same codebase, different branch.
+
+Editing files in /projects/ via jail:
+- str_replace cannot reach volume-mounted paths. Use Python via exec_sync instead.
+- Always use a quoted heredoc (<< 'PYEOF') to prevent bash from interpreting backticks, $variables, or special characters inside the Python code.
+- Prefer two small targeted replaces over one large multi-line block match — large blocks are brittle.
+
+python3 << 'PYEOF'
+with open('/projects/server/path/to/file', 'r') as f:
+    content = f.read()
+content = content.replace('old', 'new')
+with open('/projects/server/path/to/file', 'w') as f:
+    f.write(content)
+print('ok')
+PYEOF
 
 project:
 task:
-

--- a/doc/prompts/claude-code.md
+++ b/doc/prompts/claude-code.md
@@ -1,0 +1,3 @@
+read AGENTS.md at the root first, if it doesn't exist, mention this to user.
+search for project docs in .md files under doc/, fast way to discover the codebase.
+note that PR titles must be conventional commits.

--- a/doc/prompts/code-reviewer.md
+++ b/doc/prompts/code-reviewer.md
@@ -1,0 +1,5 @@
+You are a code review agent providing code review for another agent.
+You will receive the code or the plan they are interested in implementing and any context necessary.
+Provide code review optimized for an agent, not a human.
+Ask questions if necessary and be critical.
+Above all, provide a good review!

--- a/doc/prompts/prompts.md
+++ b/doc/prompts/prompts.md
@@ -1,0 +1,23 @@
+
+## claude code
+
+read AGENTS.md at the root first, if it doesn't exist, mention this to user.
+search for project docs in .md files under doc/, fast way to discover the codebase.
+note that PR titles must be conventional commits.
+
+## start a work session in chat
+
+check your jail mcp tools for a context tool, and call it on the project I'll provide.
+exec sync is the tool for most tasks, it's a shell: cat, find, grep, sed.
+for security, this is the only way to interact with project files.
+if the project's programming language isn't installed, call the setup tool on the project path.
+exec background is for slow commands, and multitasking.
+fyi: projects name like foo, foo-1, are just worktrees of foo.
+start here:
+1) read AGENTS.md at the root first, search for project docs in .md files, normally under doc/.
+2) if necessary: start the setup tool and while it runs in background, go do some other work.
+Go projects might have private dependencies that won't install unless setup tool is ran (bin/setup normally)
+
+project: 
+task:
+

--- a/doc/prompts/sql-work-jail.md
+++ b/doc/prompts/sql-work-jail.md
@@ -1,0 +1,33 @@
+Let's work with postgreSQL and queries.
+Call the jail MCP context tool at the start of each session to orient yourself.
+You should have direct access to the database using the postgres MCP tool.
+
+Database documentation should be under /projects/\*/doc/db.
+If there is no documentation, offer to build one.
+
+- README.md — full table index with descriptions
+- public.<table>.md — per-table columns, indexes, constraints, and FK relations
+
+Before writing a query, read the relevant table docs if you're unsure of column names or relationships.
+Prefer read-only queries (SELECT), mutate data only if asked explicitly.
+
+## Modes
+
+user can turn modes on and off.
+at the beginning of the session inform which modes exist and which are ON.
+
+Mirror mode: After running a query, display the query to the user.
+Output mode: After running a query, display raw query output to the user, after any output from mirror mode.
+Summary mode: After running a query, produce a concise, information-rich natural language summary of the results.
+Prioritize operationally relevant fields (dates, names, types, statuses, modalities).
+Omit raw IDs, redundant nulls, and column noise.
+Example: "Jan 9, 2026 · 1:00–1:40 PM UTC · Virtual — Obat For All (60 min) with Melissa Gorrin, RN · not cancelled, not group therapy."
+
+summary mode: default ON.
+mirror mode: default ON.
+output mode: default OFF.
+
+## Instructions
+
+project:
+task:

--- a/dotfiles/.aliases.sh
+++ b/dotfiles/.aliases.sh
@@ -246,6 +246,7 @@ alias jn="jj new"
 alias jsq="jj squash -m"
 alias jre="jj resolve"
 alias jbf="jj bookmark forget"
+alias jd="jj diff"
 
 # general
 alias la='ls -A'

--- a/dotfiles/.bash_env
+++ b/dotfiles/.bash_env
@@ -4,7 +4,7 @@
 # BASH_ENV must be set to this script in bash config files
 
 # envs
-export GOPRIVATE="github.com/eleanorhealth/\* github.com/tcodes0/\*"
+export GOPRIVATE="github.com/eleanorhealth/* github.com/tcodes0/*"
 export T0_COLOR=true
 
 # shellcheck source=lib.sh

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -88,7 +88,7 @@ if macos; then
   src_dotfile ".bashrc.mac.sh" "$LINENO"
   src_dotfile ".aliases.mac.sh" "$LINENO"
   src_dotfile ".functions.mac.sh" "$LINENO"
-  src /opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.bash.inc "$DOTFILES/.bashrc:$LINENO"
+  src /opt/homebrew/Caskroom/gcloud-cli/latest/google-cloud-sdk/path.bash.inc "$DOTFILES/.bashrc:$LINENO"
 else
   src_dotfile ".bashrc.linux.sh" "$LINENO"
   src_dotfile ".aliases.linux.sh" "$LINENO"

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -41,7 +41,7 @@ export GPG_TTY=$(tty)
 export XDG_RUNTIME_DIR
 export WAYLAND_DISPLAY
 # see lazy-git
-export PUSH_REPOS="member-client go-common interface priv hub-client server server-1 server-2 server-3 server-4 member-server shared go-athenahealth scheduling jail-mcp comms programming-problems"
+export PUSH_REPOS="member-client go-common interface priv hub-client server server-1 member-server shared go-athenahealth scheduling jail-mcp comms programming-problems online-start go compose-files"
 
 # libs
 src_dotfile "lib.sh" "$LINENO"

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -20,7 +20,7 @@ src_dotfile() {
 }
 
 export DOTFILES="$HOME/Desktop/interface/dotfiles"
-export GOPRIVATE="github.com/eleanorhealth/\* github.com/tcodes0/\*"
+export GOPRIVATE="github.com/eleanorhealth/* github.com/tcodes0/*"
 export BASH_ENV="$HOME/.bash_env"
 export CMD_COLOR=true
 export T0_COLOR=true

--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -9,7 +9,7 @@ src() {
   local path=$1 fileLine=$2
 
   # shellcheck disable=SC1090
-  if ! source "$path" 2>/dev/null; then
+  if ! source "$path"; then
     echo "$fileLine" source "$path": not found
   fi
 }

--- a/dotfiles/.bashrc.mac.sh
+++ b/dotfiles/.bashrc.mac.sh
@@ -18,6 +18,7 @@ export GOBIN=$HOME/go/bin
 export PATH="\
 $HOME/.local/share/mise/shims:\
 $HOME/bin:\
+$HOME/.local/bin:\
 /opt/homebrew/bin:\
 /opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:\
 /Applications/Docker.app/Contents/Resources/bin:\

--- a/dotfiles/.bashrc.mac.sh
+++ b/dotfiles/.bashrc.mac.sh
@@ -8,7 +8,7 @@
 if [ ! "$(pgrep ssh-agent)" ]; then
   eval "$(ssh-agent)" >/dev/null
 elif [[ ! "$SSH_AUTH_SOCK" =~ $(pgrep ssh-agent) ]]; then
-  SSH_AUTH_SOCK=$(find /var/folders -name 'agent.*' 2>/dev/null)
+  SSH_AUTH_SOCK=$(find /var/folders -name 'agent.*' 2>/dev/null | head -1)
 fi
 
 export GOPATH=$HOME/go

--- a/dotfiles/.config/Claude/claude_desktop_config.json
+++ b/dotfiles/.config/Claude/claude_desktop_config.json
@@ -11,15 +11,21 @@
         "-i",
         "jail-mcp"
       ]
+    },
+    "postgres_local": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://postgres:@localhost:5432/hub"
+      ]
     }
   },
   "isUsingBuiltInNodeForMcp": false,
   "preferences": {
     "quickEntryShortcut": "off",
     "quickEntryDictationShortcut": "capslock",
-    "localAgentModeTrustedFolders": [
-      "/usr/lib/claude-desktop-bin/app.asar"
-    ],
+    "localAgentModeTrustedFolders": ["/usr/lib/claude-desktop-bin/app.asar"],
     "coworkScheduledTasksEnabled": true,
     "ccdScheduledTasksEnabled": true,
     "sidebarMode": "code",

--- a/dotfiles/.config/Claude/claude_desktop_config.mac.json
+++ b/dotfiles/.config/Claude/claude_desktop_config.mac.json
@@ -11,6 +11,14 @@
         "-i",
         "jail-mcp"
       ]
+    },
+    "postgres_local": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://postgres:@localhost:5432/hub"
+      ]
     }
   },
   "isUsingBuiltInNodeForMcp": false,

--- a/dotfiles/.config/Claude/claude_desktop_config.mac.json
+++ b/dotfiles/.config/Claude/claude_desktop_config.mac.json
@@ -12,12 +12,76 @@
         "jail-mcp"
       ]
     },
-    "postgres_local": {
+    "local_hub": {
       "command": "uvx",
       "args": [
         "pgsql-mcp-server",
         "--dsn",
         "postgresql://postgres:@localhost:5432/hub"
+      ]
+    },
+    "local_member": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://postgres:@localhost:5432/member"
+      ]
+    },
+    "local_hub_test": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://postgres:@localhost:5432/hub_test"
+      ]
+    },
+    "local_member_test": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://postgres:@localhost:5432/member_test"
+      ]
+    },
+    "local_comms_docker": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://postgres:password@localhost:3501/comms"
+      ]
+    },
+    "qa_hub": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://thom.ribeiro%40eleanorhealth.com@/hub?host=/Users/thom.ribeiro/.eleanor_sql_sockets/ele-qa-436057:us-east1:eleanor-postgres"
+      ]
+    },
+    "qa_scheduling": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://thom.ribeiro%40eleanorhealth.com@/scheduling?host=/Users/thom.ribeiro/.eleanor_sql_sockets/ele-qa-436057:us-east1:eleanor-postgres"
+      ]
+    },
+    "qa_member": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://thom.ribeiro%40eleanorhealth.com@/member?host=/Users/thom.ribeiro/.eleanor_sql_sockets/ele-qa-436057:us-east1:eleanor-postgres"
+      ]
+    },
+    "qa_comms": {
+      "command": "uvx",
+      "args": [
+        "pgsql-mcp-server",
+        "--dsn",
+        "postgresql://thom.ribeiro%40eleanorhealth.com@/comms?host=/Users/thom.ribeiro/.eleanor_sql_sockets/ele-qa-436057:us-east1:eleanor-postgres"
       ]
     }
   },

--- a/dotfiles/.config/code-oss/User/keybindings.json
+++ b/dotfiles/.config/code-oss/User/keybindings.json
@@ -3,685 +3,693 @@
   {
     "key": "alt+tab",
     "command": "editor.action.reindentlines",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "alt+;",
     "command": "editor.action.commentLine",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "alt+q",
     "command": "editor.action.clipboardCutAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "alt+w",
     "command": "editor.action.clipboardCopyAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "meta+w",
     "command": "editor.action.clipboardCutAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "meta+alt+t",
-    "command": "-workbench.action.terminal.toggleTerminal"
+    "command": "-workbench.action.terminal.toggleTerminal",
   },
   {
     "key": "ctrl+/",
     "command": "-editor.action.commentLine",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "meta+w",
-    "command": "-workbench.action.switchWindow"
+    "command": "-workbench.action.switchWindow",
   },
   {
     "key": "alt+ctrl+f",
-    "command": "-editor.action.startFindReplaceAction"
+    "command": "-editor.action.startFindReplaceAction",
   },
   {
     "key": "alt+ctrl+/",
     "command": "toggleFindRegex",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "alt+ctrl+r",
     "command": "-toggleFindRegex",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "alt+ctrl+/",
     "command": "toggleSearchRegex",
-    "when": "searchInputBoxFocus && searchViewletVisible"
+    "when": "searchInputBoxFocus && searchViewletVisible",
   },
   {
     "key": "alt+ctrl+r",
     "command": "-toggleSearchRegex",
-    "when": "searchInputBoxFocus && searchViewletVisible"
+    "when": "searchInputBoxFocus && searchViewletVisible",
   },
   {
     "key": "alt+ctrl+e",
     "command": "editor.action.replaceAll",
-    "when": "editorFocus && findWidgetVisible"
+    "when": "editorFocus && findWidgetVisible",
   },
   {
     "key": "alt+ctrl+enter",
     "command": "-editor.action.replaceAll",
-    "when": "editorFocus && findWidgetVisible"
+    "when": "editorFocus && findWidgetVisible",
   },
   {
     "key": "alt+ctrl+e",
     "command": "editor.action.replaceOne",
-    "when": "editorFocus && findWidgetVisible"
+    "when": "editorFocus && findWidgetVisible",
   },
   {
     "key": "shift+ctrl+1",
     "command": "-editor.action.replaceOne",
-    "when": "editorFocus && findWidgetVisible"
+    "when": "editorFocus && findWidgetVisible",
   },
   {
     "key": "alt+ctrl+e",
     "command": "search.action.replace",
-    "when": "matchFocus && replaceActive && searchViewletVisible"
+    "when": "matchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "shift+ctrl+1",
     "command": "-search.action.replace",
-    "when": "matchFocus && replaceActive && searchViewletVisible"
+    "when": "matchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "ctrl+enter",
     "command": "search.action.replaceAllInFile",
-    "when": "fileMatchFocus && replaceActive && searchViewletVisible"
+    "when": "fileMatchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "shift+ctrl+1",
     "command": "-search.action.replaceAllInFile",
-    "when": "fileMatchFocus && replaceActive && searchViewletVisible"
+    "when": "fileMatchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "ctrl+enter",
     "command": "search.action.replaceAllInFolder",
-    "when": "folderMatchFocus && replaceActive && searchViewletVisible"
+    "when": "folderMatchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "shift+ctrl+1",
     "command": "-search.action.replaceAllInFolder",
-    "when": "folderMatchFocus && replaceActive && searchViewletVisible"
+    "when": "folderMatchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "ctrl+enter",
     "command": "search.action.replaceAll",
-    "when": "replaceActive && searchViewletVisible && !findWidgetVisible"
+    "when": "replaceActive && searchViewletVisible && !findWidgetVisible",
   },
   {
     "key": "alt+ctrl+enter",
     "command": "-search.action.replaceAll",
-    "when": "replaceActive && searchViewletVisible && !findWidgetVisible"
+    "when": "replaceActive && searchViewletVisible && !findWidgetVisible",
   },
   {
     "key": "shift+ctrl+enter",
     "command": "-search.action.replaceAllInFile",
-    "when": "fileMatchFocus && replaceActive && searchViewletVisible"
+    "when": "fileMatchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "shift+ctrl+enter",
     "command": "-search.action.replaceAllInFolder",
-    "when": "folderMatchFocus && replaceActive && searchViewletVisible"
+    "when": "folderMatchFocus && replaceActive && searchViewletVisible",
   },
   {
     "key": "ctrl+enter",
     "command": "-editor.action.insertLineAfter",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "shift+enter",
     "command": "editor.action.insertLineBefore",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "shift+ctrl+enter",
     "command": "-editor.action.insertLineBefore",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "meta+ctrl+l",
     "command": "editor.action.selectHighlights",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "meta+ctrl+g",
     "command": "-editor.action.selectHighlights",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "alt+d",
     "command": "deleteWordRight",
-    "when": "textInputFocus && !editorReadonly"
+    "when": "textInputFocus && !editorReadonly",
   },
   {
     "key": "alt+delete",
     "command": "-workbench.action.terminal.deleteWordRight",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "alt+s",
     "command": "workbench.action.terminal.deleteWordLeft",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "alt+s",
     "command": "deleteWordLeft",
-    "when": "textInputFocus && !editorReadonly"
+    "when": "textInputFocus && !editorReadonly",
   },
   {
     "key": "alt+s",
     "command": "deleteWordLeft",
-    "when": "textInputFocus && !editorReadonly"
+    "when": "textInputFocus && !editorReadonly",
   },
   {
     "key": "alt+backspace",
     "command": "deleteWordLeft",
-    "when": "textInputFocus && !editorReadonly"
+    "when": "textInputFocus && !editorReadonly",
   },
   {
     "key": "alt+w",
     "command": "workbench.action.terminal.copySelection",
-    "when": "terminalFocus && terminalTextSelected"
+    "when": "terminalFocus && terminalTextSelected",
   },
   {
     "key": "shift+alt+up",
     "command": "-editor.action.copyLinesUpAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "ctrl+k ctrl+c",
     "command": "-editor.action.addCommentLine",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "meta+k",
     "command": "-deleteAllRight",
-    "when": "textInputFocus && !editorReadonly"
+    "when": "textInputFocus && !editorReadonly",
   },
   {
     "key": "ctrl+i",
     "command": "-expandLineSelection",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "shift+ctrl+left",
     "command": "workbench.action.terminal.focusPreviousPane",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "shift+ctrl+left",
-    "command": "workbench.action.previousEditor"
+    "command": "workbench.action.previousEditor",
   },
   {
     "key": "shift+ctrl+left",
     "command": "-cursorHomeSelect",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "shift+ctrl+right",
     "command": "-cursorEndSelect",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "shift+ctrl+right",
     "command": "workbench.action.terminal.focusNextPane",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "shift+ctrl+right",
-    "command": "workbench.action.nextEditor"
+    "command": "workbench.action.nextEditor",
   },
   {
     "key": "ctrl+e",
-    "command": "-actions.findWithSelection"
+    "command": "-actions.findWithSelection",
   },
   {
     "key": "ctrl+e",
     "command": "editor.action.smartSelect.grow",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "meta+shift+ctrl+right",
     "command": "-editor.action.smartSelect.grow",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "ctrl+y",
-    "command": "-redo"
+    "command": "-redo",
   },
   {
     "key": "ctrl+c",
     "command": "editor.action.clipboardCopyAction",
-    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+    "when": "editorFocus && findInputFocussed && findWidgetVisible",
   },
   {
     "key": "alt+w",
     "command": "editor.action.clipboardCopyAction",
-    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+    "when": "editorFocus && findInputFocussed && findWidgetVisible",
   },
   {
     "key": "down",
     "command": "history.showNext",
-    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+    "when": "editorFocus && findInputFocussed && findWidgetVisible",
   },
   {
     "key": "alt+down",
     "command": "-history.showNext",
-    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+    "when": "editorFocus && findInputFocussed && findWidgetVisible",
   },
   {
     "key": "down",
     "command": "history.showNext",
-    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible",
   },
   {
     "key": "alt+down",
     "command": "-history.showNext",
-    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible",
   },
   {
     "key": "up",
     "command": "history.showPrevious",
-    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+    "when": "editorFocus && findInputFocussed && findWidgetVisible",
   },
   {
     "key": "alt+up",
     "command": "-history.showPrevious",
-    "when": "editorFocus && findInputFocussed && findWidgetVisible"
+    "when": "editorFocus && findInputFocussed && findWidgetVisible",
   },
   {
     "key": "up",
     "command": "history.showPrevious",
-    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible",
   },
   {
     "key": "alt+up",
     "command": "-history.showPrevious",
-    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible"
+    "when": "terminalFindWidgetInputFocused && terminalFindWidgetVisible",
   },
   {
     "key": "ctrl+k ctrl+u",
     "command": "-editor.action.removeCommentLine",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "ctrl+k ctrl+u",
-    "command": "editor.action.transformToUppercase"
+    "command": "editor.action.transformToUppercase",
   },
   {
     "key": "ctrl+k ctrl+l",
-    "command": "editor.action.transformToLowercase"
+    "command": "editor.action.transformToLowercase",
   },
   {
     "key": "alt+ctrl+r",
     "command": "-text-transformer.reverse",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "alt+ctrl+c",
     "command": "-text-transformer.camel",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "alt+ctrl+d",
     "command": "-text-transformer.dashed",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "alt+ctrl+l",
     "command": "-text-transformer.lower",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "alt+ctrl+z",
     "command": "-text-transformer.underline",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "alt+ctrl+u",
     "command": "-text-transformer.upper",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "meta+`",
     "command": "workbench.action.terminal.focus",
-    "when": "!terminalFocus"
+    "when": "!terminalFocus",
   },
   {
     "key": "meta+`",
     "command": "workbench.action.focusActiveEditorGroup",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "meta+`",
-    "command": "-workbench.action.terminal.toggleTerminal"
+    "command": "-workbench.action.terminal.toggleTerminal",
   },
   {
     "key": "ctrl+k ctrl+t",
-    "command": "workbench.action.terminal.toggleTerminal"
+    "command": "workbench.action.terminal.toggleTerminal",
   },
   {
     "key": "ctrl+u",
     "command": "editor.action.deleteLines",
-    "when": "textInputFocus && !editorReadonly"
+    "when": "textInputFocus && !editorReadonly",
   },
   {
     "key": "ctrl+i",
     "command": "editor.action.copyLinesDownAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "shift+ctrl+g",
-    "command": "-workbench.view.scm"
+    "command": "-workbench.view.scm",
   },
   {
     "key": "meta+shift+9",
-    "command": "workbench.view.scm"
+    "command": "workbench.view.scm",
   },
   {
     "key": "ctrl+k ctrl+p",
     "command": "extension.colorHelper.pick",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "ctrl+k ctrl+o",
-    "command": "workbench.action.focusPreviousGroup"
+    "command": "workbench.action.focusPreviousGroup",
   },
   {
     "key": "ctrl+k ctrl+d",
     "command": "-editor.action.moveSelectionToNextFindMatch",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "ctrl+k ctrl+d",
-    "command": "git.openChange"
+    "command": "git.openChange",
   },
   {
     "key": "ctrl+k ctrl+m",
-    "command": "-workbench.extensions.action.showRecommendedKeymapExtensions"
+    "command": "-workbench.extensions.action.showRecommendedKeymapExtensions",
   },
   {
     "key": "ctrl+k ctrl+m",
-    "command": "workbench.action.maximizeEditor"
+    "command": "workbench.action.maximizeEditor",
   },
   {
     "key": "ctrl+k ctrl+e",
     "command": "editor.action.peekTypeDefinition",
-    "when": "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+    "when": "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor",
   },
   {
     "key": "alt+f12",
     "command": "-editor.action.previewDeclaration",
-    "when": "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor"
+    "when": "editorHasDefinitionProvider && editorTextFocus && !inReferenceSearchEditor && !isInEmbeddedEditor",
   },
   {
     "key": "ctrl+k ctrl+y",
-    "command": "editor.action.peekTypeDefinition"
+    "command": "editor.action.peekTypeDefinition",
   },
   {
     "key": "ctrl+k ctrl+r",
-    "command": "git.revertSelectedRanges"
+    "command": "git.revertSelectedRanges",
   },
   {
     "key": "ctrl+shift+'",
     "command": "editor.action.clipboardCutAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "ctrl+'",
     "command": "editor.action.clipboardCopyAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "ctrl+0",
-    "command": "-workbench.action.focusSideBar"
+    "command": "-workbench.action.focusSideBar",
   },
   {
     "key": "ctrl+9",
-    "command": "-workbench.action.lastEditorInGroup"
+    "command": "-workbench.action.lastEditorInGroup",
   },
   {
     "key": "ctrl+9",
-    "command": "-workbench.action.openEditorAtIndex9"
+    "command": "-workbench.action.openEditorAtIndex9",
   },
   {
     "key": "ctrl+0",
-    "command": "workbench.action.moveEditorToRightGroup"
+    "command": "workbench.action.moveEditorToRightGroup",
   },
   {
     "key": "ctrl+9",
-    "command": "workbench.action.moveEditorToLeftGroup"
+    "command": "workbench.action.moveEditorToLeftGroup",
   },
   {
     "key": "ctrl+meta+up",
     "command": "editor.action.moveLinesUpAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "alt+up",
     "command": "-editor.action.moveLinesUpAction",
-    "when": "editorTextFocus && !editorReadonly"
+    "when": "editorTextFocus && !editorReadonly",
   },
   {
     "key": "ctrl+meta+down",
     "command": "editor.action.moveLinesDownAction",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "alt+down",
     "command": "-editor.action.moveLinesDownAction",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "ctrl+g",
     "command": "editor.action.nextMatchFindAction",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "f3",
     "command": "-editor.action.nextMatchFindAction",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "ctrl+shift+g",
     "command": "editor.action.previousMatchFindAction",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "shift+f3",
     "command": "-editor.action.previousMatchFindAction",
-    "when": "editorFocus"
+    "when": "editorFocus",
   },
   {
     "key": "meta+g",
-    "command": "workbench.action.gotoLine"
+    "command": "workbench.action.gotoLine",
   },
   {
     "key": "ctrl+g",
-    "command": "-workbench.action.gotoLine"
+    "command": "-workbench.action.gotoLine",
   },
   {
     "key": "ctrl+-",
-    "command": "workbench.action.navigateBack"
+    "command": "workbench.action.navigateBack",
   },
   {
     "key": "ctrl+alt+-",
-    "command": "-workbench.action.navigateBack"
+    "command": "-workbench.action.navigateBack",
   },
   {
     "key": "shift+alt+-",
-    "command": "workbench.action.navigateForward"
+    "command": "workbench.action.navigateForward",
   },
   {
     "key": "ctrl+shift+-",
-    "command": "-workbench.action.navigateForward"
+    "command": "-workbench.action.navigateForward",
   },
   {
     "key": "ctrl+a",
     "command": "-editor.action.selectAll",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "meta+e",
-    "command": "cursorLineEnd"
+    "command": "cursorLineEnd",
   },
   {
     "key": "meta+a",
-    "command": "cursorLineStart"
+    "command": "cursorLineStart",
   },
   {
     "key": "alt+right",
     "command": "-workbench.action.terminal.focusNextPane",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "alt+left",
     "command": "-workbench.action.terminal.focusPreviousPane",
-    "when": "terminalFocus"
+    "when": "terminalFocus",
   },
   {
     "key": "alt+right",
     "command": "cursorWordEndRight",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "ctrl+right",
     "command": "-cursorWordEndRight",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "alt+left",
     "command": "cursorWordStartLeft",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "ctrl+left",
     "command": "-cursorWordStartLeft",
-    "when": "textInputFocus"
+    "when": "textInputFocus",
   },
   {
     "key": "ctrl+-",
-    "command": "-workbench.action.zoomOut"
+    "command": "-workbench.action.zoomOut",
   },
   {
     "key": "ctrl+k ctrl+s",
-    "command": "-workbench.action.openGlobalKeybindings"
+    "command": "-workbench.action.openGlobalKeybindings",
   },
   {
     "key": "ctrl+k ctrl+s",
     "command": "git.stageSelectedRanges",
-    "when": "isInDiffEditor"
+    "when": "isInDiffEditor",
   },
   {
     "key": "ctrl+k ctrl+9",
     "command": "-editor.unfoldAllMarkerRegions",
-    "when": "editorTextFocus && foldingEnabled"
+    "when": "editorTextFocus && foldingEnabled",
   },
   {
     "key": "ctrl+k ctrl+9",
-    "command": "editor.unfoldAll"
+    "command": "editor.unfoldAll",
   },
   {
     "key": "ctrl+k ctrl+j",
     "command": "-editor.unfoldAll",
-    "when": "editorTextFocus && foldingEnabled"
+    "when": "editorTextFocus && foldingEnabled",
   },
   {
     "key": "ctrl+k k",
     "command": "deleteAllRight",
-    "when": "editorTextFocus"
+    "when": "editorTextFocus",
   },
   {
     "key": "f11",
-    "command": "-workbench.action.toggleFullScreen"
+    "command": "-workbench.action.toggleFullScreen",
   },
   {
-    "key": "shift+meta+0",
-    "command": "pr:github.focus"
+    "key": "ctrl+shift+0",
+    "command": "pr:github.focus",
   },
   {
     "key": "ctrl+shift+d",
     "command": "-workbench.view.debug",
-    "when": "viewContainer.workbench.view.debug.enabled"
+    "when": "viewContainer.workbench.view.debug.enabled",
   },
   {
     "key": "ctrl+shift+d",
-    "command": "editor.action.duplicateSelection"
+    "command": "editor.action.duplicateSelection",
   },
   {
     "key": "ctrl+j",
-    "command": "editor.action.joinLines"
+    "command": "editor.action.joinLines",
   },
   {
     "key": "ctrl+f",
     "command": "editor.action.startFindReplaceAction",
-    "when": "editorFocus || editorIsOpen"
+    "when": "editorFocus || editorIsOpen",
   },
   {
     "key": "ctrl+h",
     "command": "-editor.action.startFindReplaceAction",
-    "when": "editorFocus || editorIsOpen"
+    "when": "editorFocus || editorIsOpen",
   },
   {
     "key": "ctrl+r",
-    "command": "-workbench.action.gotoSymbol"
+    "command": "-workbench.action.gotoSymbol",
   },
   {
     "key": "ctrl+o",
     "command": "-workbench.action.files.openFile",
-    "when": "true"
+    "when": "true",
   },
   {
     "key": "ctrl+o",
     "command": "workbench.action.gotoSymbol",
-    "when": "!accessibilityHelpIsShown && !accessibleViewIsShown"
+    "when": "!accessibilityHelpIsShown && !accessibleViewIsShown",
   },
   {
     "key": "ctrl+shift+o",
     "command": "-workbench.action.gotoSymbol",
-    "when": "!accessibilityHelpIsShown && !accessibleViewIsShown"
+    "when": "!accessibilityHelpIsShown && !accessibleViewIsShown",
   },
   {
     "key": "ctrl+v",
-    "command": "-editor.action.clipboardPasteAction"
+    "command": "-editor.action.clipboardPasteAction",
   },
   {
     "key": "ctrl+v",
     "command": "-filesExplorer.paste",
-    "when": "filesExplorerFocus && foldersViewVisible && !explorerResourceReadonly && !inputFocus"
+    "when": "filesExplorerFocus && foldersViewVisible && !explorerResourceReadonly && !inputFocus",
   },
   {
     "key": "shift+insert",
-    "command": "-editor.action.clipboardPasteAction"
+    "command": "-editor.action.clipboardPasteAction",
   },
   {
     "key": "alt+e",
     "command": "paste",
-    "when": "editorFocus && !editorReadonly"
+    "when": "editorFocus && !editorReadonly",
   },
   {
     "key": "ctrl+=",
-    "command": "-workbench.action.zoomIn"
+    "command": "-workbench.action.zoomIn",
   },
   {
     "key": "ctrl+numpad_add",
-    "command": "-workbench.action.zoomIn"
+    "command": "-workbench.action.zoomIn",
   },
   {
     "key": "ctrl+shift+=",
-    "command": "-workbench.action.zoomIn"
+    "command": "-workbench.action.zoomIn",
   },
   {
     "key": "ctrl+numpad_subtract",
-    "command": "-workbench.action.zoomOut"
-  }
+    "command": "-workbench.action.zoomOut",
+  },
+  {
+    "key": "ctrl+shift+8",
+    "command": "go.test.profile.focus",
+  },
+  {
+    "key": "ctrl+shift+8",
+    "command": "workbench.view.testing.focus",
+  },
 ]

--- a/dotfiles/.config/code-oss/User/settings.json
+++ b/dotfiles/.config/code-oss/User/settings.json
@@ -61,8 +61,8 @@
   "terminal.integrated.splitCwd": "inherited",
   "editor.fontFamily": "PragmataPro Liga",
   "editor.fontWeight": "normal",
-  "editor.lineHeight": 21,
-  "editor.fontSize": 14,
+  "editor.lineHeight": 20,
+  "editor.fontSize": 13,
   //
   // - - - - - - - - FORMATTER & LINTER - - - - - - - - -
   //
@@ -366,6 +366,7 @@
     "plaintext": false,
     "markdown": false,
     "scminput": false,
+    "go": false,
   },
   "[github-actions-workflow]": {
     "editor.defaultFormatter": "redhat.vscode-yaml",

--- a/dotfiles/.config/code-oss/User/settings.json
+++ b/dotfiles/.config/code-oss/User/settings.json
@@ -474,4 +474,5 @@
   "redhat.telemetry.enabled": true,
   "security.workspace.trust.untrustedFiles": "open",
   "explorer.confirmPasteNative": false,
+  "workbench.secondarySideBar.defaultVisibility": "hidden",
 }

--- a/dotfiles/.config/code/User/keybindings.json
+++ b/dotfiles/.config/code/User/keybindings.json
@@ -721,5 +721,9 @@
   {
     "key": "cmd+-",
     "command": "-workbench.action.zoomOut"
+  },
+  {
+    "key": "shift+cmd+8",
+    "command": "workbench.view.extension.test"
   }
 ]

--- a/dotfiles/.config/gtk-4.0/gtk.css
+++ b/dotfiles/.config/gtk-4.0/gtk.css
@@ -1,0 +1,8 @@
+@import 'colors.css';
+
+/* overrides */
+@define-color window_bg_color #000000;
+@define-color view_bg_color #000000;
+@define-color headerbar_bg_color #000000;
+@define-color card_bg_color #0a0a0a;
+@define-color popover_bg_color #0a0a0a;

--- a/dotfiles/.config/mise/config.toml
+++ b/dotfiles/.config/mise/config.toml
@@ -1,0 +1,6 @@
+[tools]
+go = "latest"
+node = "latest"
+npm = "latest"
+uv = "latest"
+yarn = "1.22.22"

--- a/dotfiles/.config/systemd/user/default.target.wants/ele-cloudsql.service
+++ b/dotfiles/.config/systemd/user/default.target.wants/ele-cloudsql.service
@@ -1,0 +1,1 @@
+/home/vacation/.config/systemd/user/ele-cloudsql.service

--- a/dotfiles/.config/systemd/user/default.target.wants/jailmcphttp.service
+++ b/dotfiles/.config/systemd/user/default.target.wants/jailmcphttp.service
@@ -1,0 +1,1 @@
+/home/vacation/.config/systemd/user/jailmcphttp.service

--- a/dotfiles/.config/systemd/user/ele-cloudsql.service
+++ b/dotfiles/.config/systemd/user/ele-cloudsql.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Google Cloud SQL Proxy for Eleanor projects
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/vacation/Desktop/scripts-eleanor/ele-cloudsql.sh
+Restart=on-failure
+RestartSec=5
+# Ensure the PATH includes the directory where cloud-sql-proxy lives
+Environment="PATH=/home/vacation/bin:/usr/local/bin:/usr/bin:/bin"
+
+[Install]
+WantedBy=default.target

--- a/dotfiles/.config/systemd/user/jailmcphttp.service
+++ b/dotfiles/.config/systemd/user/jailmcphttp.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Jail MCP HTTP Server
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/home/vacation/bin/jailmcphttp
+Restart=on-failure
+RestartSec=5
+Environment="JAIL_MCP_TIMEOUT=15s"
+Environment="JAIL_MCP_BACKGROUND_TIMEOUT=5m"
+Environment="JAIL_MCP_TRANSPORT=mcp-proxy"
+Environment="PATH=/home/vacation/bin:/home/vacation/.local/bin:/usr/local/bin:/usr/bin:/bin"
+
+[Install]
+WantedBy=default.target

--- a/dotfiles/.config/systemd/user/ollama.service
+++ b/dotfiles/.config/systemd/user/ollama.service
@@ -10,8 +10,13 @@ Environment="HSA_PATH=/opt/rocm"
 Environment="PATH=$PATH"
 # listen on all network interfaces, not just localhost (default)
 # makes local ollama visible to the docker bridge gateway
-Environment="OLLAMA_HOST=0.0.0.0" 
+Environment="OLLAMA_HOST=0.0.0.0"
+# wait 1h to unload a model. loading is slow
 Environment="OLLAMA_KEEP_ALIVE=1h"
+# required to enable kv cache quantization. saves vram
+Environment="OLLAMA_FLASH_ATTENTION=1"
+# kv cache quantization
+Environment="OLLAMA_KV_CACHE_TYPE=q8_0"
 Restart=always
 RestartSec=3
 Type=simple

--- a/dotfiles/.config/systemd/user/plasma-kwin_wayland.service.d/override.conf
+++ b/dotfiles/.config/systemd/user/plasma-kwin_wayland.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=KWIN_SOFTWARERENDERING=1

--- a/dotfiles/.config/systemd/user/whisper-server-cpu.service
+++ b/dotfiles/.config/systemd/user/whisper-server-cpu.service
@@ -1,13 +1,14 @@
 [Unit]
-Description=Whisper.cpp inference server (GPU)
+Description=Whisper.cpp inference server (CPU)
 # note: ffmpeg is a dependency
-Conflicts=whisper-server-cpu.service
+Conflicts=whisper-server.service
 
 [Service]
 ExecStart=/usr/bin/whisper-server \
     -m /usr/share/whisper.cpp-model-large-v3-turbo-q5_0/ggml-large-v3-turbo-q5_0.bin \
     --host 127.0.0.1 --port 8765 \
-    --language auto --suppress-nst --no-timestamps --convert
+    --language auto --suppress-nst --no-timestamps --convert \
+    --no-gpu --threads 6
 Restart=on-failure
 RestartSec=5
 

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -210,3 +210,4 @@ words:
   - zram
   - zswap
   - ZYMA
+  - kwin

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -44,6 +44,7 @@ words:
   - argn
   - artis
   - Asam
+  - tbls
   - ASPM
   - athenadepartmentid
   - BARC

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -68,6 +68,7 @@ words:
   - Debugf
   - devmode
   - DMAR
+  - dotenv
   - DSDT
   - EDID
   - ehff
@@ -88,6 +89,7 @@ words:
   - GLAN
   - glslang
   - godotenv
+  - gofumpt
   - goqu
   - gosec
   - gotestfmt
@@ -166,6 +168,7 @@ words:
   - rocm
   - SEVDSQ
   - SSDT
+  - sslmode
   - SSRS
   - stretchr
   - Strs

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -34,6 +34,7 @@ words:
   - ACPI
   - AGDP
   - AHCI
+  - aichat
   - aliasg
   - alnum
   - alsa
@@ -157,6 +158,7 @@ words:
   - Nower
   - OBAT
   - ollama
+  - openwebui
   - pacu
   - PAWSS
   - pgdialect

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -57,6 +57,7 @@ words:
   - CIWA
   - CIWAB
   - commitlintrc
+  - Convo
   - coreutils
   - cpio
   - CPUPM
@@ -198,6 +199,7 @@ words:
   - vacuumdb
   - vite
   - VRTL
+  - webui
   - wneessen
   - Wrapfl
   - XCPM

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -116,6 +116,7 @@ words:
   - IOUSB
   - IPIC
   - iterm
+  - jailmcphttp
   - jrb
   - kaue
   - kazuo
@@ -126,6 +127,7 @@ words:
   - Kexts
   - Komplete
   - krunner
+  - kwin
   - Laguardia
   - LARRIS
   - ldns
@@ -137,6 +139,7 @@ words:
   - lzma
   - mackup
   - MCFG
+  - mcpo
   - meds
   - Mgmt
   - Mikey
@@ -210,4 +213,3 @@ words:
   - zram
   - zswap
   - ZYMA
-  - kwin

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -53,6 +53,7 @@ words:
   - blazingly
   - btrfs
   - busid
+  - tbls
   - cfprefsd
   - CIWA
   - CIWAB

--- a/dotfiles/.cspell.config.yml
+++ b/dotfiles/.cspell.config.yml
@@ -44,7 +44,6 @@ words:
   - argn
   - artis
   - Asam
-  - tbls
   - ASPM
   - athenadepartmentid
   - BARC
@@ -54,7 +53,6 @@ words:
   - blazingly
   - btrfs
   - busid
-  - tbls
   - cfprefsd
   - CIWA
   - CIWAB
@@ -127,6 +125,7 @@ words:
   - Kexts
   - Komplete
   - krunner
+  - Laguardia
   - LARRIS
   - ldns
   - ldvalue
@@ -175,8 +174,10 @@ words:
   - stretchr
   - Strs
   - sysu
+  - tbls
   - tcodes0
   - teramoto
+  - Termius
   - testdb
   - thom
   - thomazella

--- a/dotfiles/.functions.sh
+++ b/dotfiles/.functions.sh
@@ -590,6 +590,8 @@ jgl() {
     return $?
   fi
 
+  local b=$(jj_bookmark0)
+
   jj git fetch
-  jj new "$(jj_bookmark0)"
+  jj new "$b"
 }

--- a/dotfiles/.functions.sh
+++ b/dotfiles/.functions.sh
@@ -544,13 +544,13 @@ urldecode_json() {
 #----------------
 
 save_session() {
-  echo "$PWD" "$@" >>"$HOME/Desktop/sessions.txt"
+  echo "$PWD" "$@" >>"$HOME/Desktop/txt/sessions.txt"
 }
 
 restore_session() {
   local dir="$PWD"
   local command
-  command=$(command grep "^$dir " "$HOME/Desktop/sessions.txt" | sed "s|^$dir ||")
+  command=$(command grep "^$dir " "$HOME/Desktop/txt/sessions.txt" | sed "s|^$dir ||")
 
   if [[ -z "$command" ]]; then
     echo "no session found for $dir"

--- a/dotfiles/.functions.sh
+++ b/dotfiles/.functions.sh
@@ -595,3 +595,29 @@ jgl() {
   jj git fetch
   jj new "$b"
 }
+
+#----------------
+
+# cat and copy to clipboard a prompt file under the prompts directory.
+# If an argument is given, it is used as a prefix to find the prompt file.
+# If no argument is given, lists available prompt files without extensions.
+prompt() {
+  local dir="$HOME/Desktop/interface/doc/prompts"
+  if [[ -n "$1" ]]; then
+    local file
+    file=$(find "$dir" -maxdepth 1 -type f -name "$1*" | head -1)
+
+    if [[ -n "$file" ]]; then
+      command cat "$file"
+      pbc < <(cat "$file")
+    else
+      while IFS= read -r f; do
+        basename "$f" | sed 's/\.[^.]*$//'
+      done < <(find "$dir" -maxdepth 1 -type f)
+    fi
+  else
+    while IFS= read -r f; do
+      basename "$f" | sed 's/\.[^.]*$//'
+    done < <(find "$dir" -maxdepth 1 -type f)
+  fi
+}

--- a/dotfiles/.functions.sh
+++ b/dotfiles/.functions.sh
@@ -363,30 +363,30 @@ vcs_prompt() {
 #- - - - - - - - - - -
 
 jj_prompt() {
-  local change_id description change_id_parent description_parent bookmarks=() temp temp2
+  local change_id description change_id_parent description_parent jj_bookmarks=() temp temp2
 
   temp=$(command jj log --color=always --no-graph --limit 1 --template 'change_id.shortest()  ++" desc:"++ description ++" "++ parents.map(|c| c.change_id().shortest() ++" desc:"++ c.description()) ++" "++ description ++ "\n"')
   read -r change_id description change_id_parent description_parent <<<"$temp"
 
   # color=always produces strings unsuitable for anything but display, they contain escape sequences
   temp2=$(jj log --revisions 'ancestors(@) & bookmarks()' --template 'bookmarks ++ " "' --color=always --no-graph)
-  read -ra bookmarks <<<"$temp2"
+  read -ra jj_bookmarks <<<"$temp2"
 
   # remove prefix to erase empty descriptions
   description=${description/desc:/}
   description_parent=${description_parent/desc:/}
   # set empty if second parent bookmark is main or master
-  bookmarks[1]=${bookmarks[1]/main/}
-  bookmarks[1]=${bookmarks[1]/master/}
+  jj_bookmarks[1]=${jj_bookmarks[1]/main/}
+  jj_bookmarks[1]=${jj_bookmarks[1]/master/}
 
   # local repo_root
 
   # if repo_root=$(command jj root 2>/dev/null); then
-  #   track_jj_bookmarks "$repo_root" "${bookmarks[0]}"
+  #   track_jj_bookmarks "$repo_root" "${jj_bookmarks[0]}"
   # fi
 
   local light_black="\\[\\e[33;90m\\]" green="\\[\\e[33;32m\\]"
-  local format="${bookmarks[0]} ${bookmarks[1]} $green@$END$change_id $description $green@-$END$change_id_parent $light_black$description_parent$END"
+  local format="${jj_bookmarks[0]} ${jj_bookmarks[1]} $green@$END$change_id $description $green@-$END$change_id_parent $light_black$description_parent$END"
 
   # strip double spaces
   format=${format//  / }
@@ -570,4 +570,26 @@ lg() {
 
   lazy-jujutsu "$@"
   return $?
+}
+
+#----------------
+
+jj_bookmark0() {
+  read -ra bookmark _ < <(jj log --revisions 'ancestors(@) & bookmarks()' --template 'bookmarks ++ " "' --no-graph)
+  printf "%s" "${bookmark[0]}"
+}
+
+#----------------
+
+# jj "git pull"
+# JJ git fetch changes the bookmark to the most current one. We want to stay on the current bookmark.
+# So after fetch we switch back.
+jgl() {
+  if ! command jj root &>/dev/null; then
+    git pull
+    return $?
+  fi
+
+  jj git fetch
+  jj new "$(jj_bookmark0)"
 }

--- a/dotfiles/lib-git-prompt.sh
+++ b/dotfiles/lib-git-prompt.sh
@@ -124,7 +124,7 @@ __git_ps1_show_upstream() {
       fi
       ;;
     svn-remote.*.url)
-      svn_remote[${#svn_remote[@]}+1]="$value"
+      svn_remote[${#svn_remote[@]} + 1]="$value"
       svn_url_pattern="$svn_url_pattern\\|$value"
       upstream=svn+git # default upstream is SVN if available, else git
       ;;
@@ -151,7 +151,7 @@ __git_ps1_show_upstream() {
     mapfile -t svn_upstream < <(git log --first-parent -1 \
       --grep="^git-svn-id: \(${svn_url_pattern#??}\)" 2>/dev/null)
     if [[ 0 -ne ${#svn_upstream[@]} ]]; then
-      local svn_upstream_str=${svn_upstream[${#svn_upstream[@]}-2]}
+      local svn_upstream_str=${svn_upstream[${#svn_upstream[@]} - 2]}
       svn_upstream_str=${svn_upstream_str%@*}
       local n_stop="${#svn_remote[@]}"
       for ((n = 1; n <= n_stop; n++)); do
@@ -195,28 +195,38 @@ __git_ps1_show_upstream() {
   if [[ -z "$verbose" ]]; then
     case "$count" in
     "") # no upstream
-      p="" ;;
+      p=""
+      ;;
     "0	0") # equal to upstream
-      p="=" ;;
+      p="="
+      ;;
     "0	"*) # ahead of upstream
-      p=">" ;;
+      p=">"
+      ;;
     *"	0") # behind upstream
-      p="<" ;;
+      p="<"
+      ;;
     *) # diverged from upstream
-      p="<>" ;;
+      p="<>"
+      ;;
     esac
   else
     case "$count" in
     "") # no upstream
-      p="" ;;
+      p=""
+      ;;
     "0	0") # equal to upstream
-      p=" =" ;;
+      p=" ="
+      ;;
     "0	"*) # ahead of upstream
-      p=" +${count#0	}" ;;
+      p=" +${count#0	}"
+      ;;
     *"	0") # behind upstream
-      p=" -${count%	0}" ;;
+      p=" -${count%	0}"
+      ;;
     *) # diverged from upstream
-      p=" +${count#*	}-${count%	*}" ;;
+      p=" +${count#*	}-${count%	*}"
+      ;;
     esac
     if [[ -n "$count" && -n "$name" ]]; then
       __git_ps1_upstream_name=$(git rev-parse \

--- a/etc/systemd/system/ollama-unload.service
+++ b/etc/systemd/system/ollama-unload.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Unload Ollama models from VRAM before sleep
+Before=sleep.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/vacation/Desktop/interface/bin/ollama-unload
+
+[Install]
+WantedBy=sleep.target


### PR DESCRIPTION

###  Claude / MCP Config (3)
Two of these appear to be duplicates — postgres MCP was added twice under slightly different paths:
- `48625b4`, `0cabf07` — add postgres MCP server to mac Claude config
- `958dc14` — add postgres MCP server + `uv` to Claude Desktop

---

###  Systemd / Services / Ollama (4)
Expanding local AI and desktop service setup:
- `130fe57` — several new user services + ollama sleep fix
- `21d5fbd` — whisper-server CPU user service
- `e9af49e` — KWin user service with software rendering
- `2233616` — ollama KV cache quantization env vars

---

###  Shell / Dotfiles / Functions (6)
Shell config and function updates:
- `3fff466` — add mise to `.config`
- `3ad7e95` — fix asterisk escaping in `.bashrc`
- `38fb69a` — update `PUSH_REPOS` in `.bashrc`
- `b22b568` — new `jgl` function, smaller editor font
- `d5d0cf4` — fix `jgl` branch switching
- `27f0ea6` — add prompt helpers to `.functions`

---

###  Prompts / Docs (5)
Building out the prompts library and docs:
- `692e64e`, `c871751` — add prompts (general + SQL work)
- `bd72ac3` — split prompt files
- `bd72ac3` *(chat-work-session-jail)* — improve edit instructions
- `ec5a1c7`, `2deb03a` — update ideas and install docs

---

###  Bin Scripts (2)
- `ae1a73f` — run `mise update` as root in `system-up`
- `61c1d83` — fix `download-youtube-id` for IDs starting with `-`

---

###  Misc / Housekeeping (6)
Spell check, shortcuts, gitignore, and other small tweaks:
- `7944964`, `c6cb944` — cspell config updates
- `341a4fb`, `20194ca` — keyboard shortcuts (general + VSCode OSS)
- `d732e20` — gitignore
- `9d1d7ea` — misc