### PR TITLE
fix(compose-setup): use lowercase script_dir in env_file

### DIFF
--- a/bin/compose-setup
+++ b/bin/compose-setup
@@ -39,7 +39,6 @@ assemble() {
   local fn
 
   cat "$PARTS_DIR/header.sh"
-  echo
   for fn in $funcs; do
     cat "$PARTS_DIR/${fn}.sh"
     echo

--- a/src/compose-setup/env_file.sh
+++ b/src/compose-setup/env_file.sh
@@ -4,7 +4,7 @@ env_file() {
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local ENV_FILE="$script_dir/../.env"
-  if [[ ! -f "$ENV_FILE" && -f "$SCRIPT_DIR/../.env-default" ]]; then
-    cp "$SCRIPT_DIR/../.env-default" "$ENV_FILE"
+  if [[ ! -f "$ENV_FILE" && -f "$script_dir/../.env-default" ]]; then
+    cp "$script_dir/../.env-default" "$ENV_FILE"
   fi
 }


### PR DESCRIPTION
The `env_file()` function declared `script_dir` as a local lowercase variable but then referenced `$SCRIPT_DIR` (uppercase) in the condition and copy command, causing an unbound variable error under `set -u`.

Fixes the two references to use the correct `$script_dir` variable.