### PR TITLE
fix(prompts): read GITHUB_TOKEN from environment, not .env

### DIFF
--- a/doc/prompts/agent-merlin.md
+++ b/doc/prompts/agent-merlin.md
@@ -87,7 +87,7 @@ Run these steps in order:
 
 ```bash
 # wire up gh CLI (idempotent, /root persists)
-# GITHUB_TOKEN is injected by the mcpjail container as a Docker secret -- read it directly from the environment
+# GITHUB_TOKEN is injected in the environment
 mkdir -p ~/.config/gh
 printf 'github.com:\n    oauth_token: %s\n    user: rthomazel\n    git_protocol: https\n' "$GITHUB_TOKEN" > ~/.config/gh/hosts.yml
 ```

--- a/doc/prompts/agent-merlin.md
+++ b/doc/prompts/agent-merlin.md
@@ -86,10 +86,10 @@ Read AGENTS.md at the project root, then look for docs in .md files under doc/.
 Run these steps in order:
 
 ```bash
-# wire up gh CLI using token already in .env (idempotent, /root persists)
-TOKEN=$(grep '^GITHUB_TOKEN=' .env | cut -d= -f2-)
+# wire up gh CLI (idempotent, /root persists)
+# GITHUB_TOKEN is injected by the mcpjail container as a Docker secret -- read it directly from the environment
 mkdir -p ~/.config/gh
-printf 'github.com:\n    oauth_token: %s\n    user: rthomazel\n    git_protocol: https\n' "$TOKEN" > ~/.config/gh/hosts.yml
+printf 'github.com:\n    oauth_token: %s\n    user: rthomazel\n    git_protocol: https\n' "$GITHUB_TOKEN" > ~/.config/gh/hosts.yml
 ```
 
 # Delegation


### PR DESCRIPTION
The session start snippet was grepping for `GITHUB_TOKEN` from a `.env` file in the project root.

Not all projects have a `.env`, and tokens should not live in `.env` files. The token is now injected directly into the container environment via Docker secret (see compose-files PR).

Update the snippet to read `$GITHUB_TOKEN` from the environment directly.