### PR TITLE
docs(prompts): warn about jj branch drift before opening PRs

### DIFF
--- a/doc/prompts/agent-merlin.md
+++ b/doc/prompts/agent-merlin.md
@@ -54,6 +54,15 @@ git -C /projects/<repo> worktree add /projects/scratchpad/<repo>-<name-mmm-dd> -
 
 Reuse an existing worktree if it's on the right branch. Use plain git commits in the worktree.
 
+**Before opening a PR:** repos managed with jj may have a development branch (e.g. `0.3.0`) that is ahead of `origin/main` and never merged back yet. Never assume `main` is the right PR base. Always verify first:
+
+```bash
+git -C /projects/<repo> branch -r          # see what remote branches exist
+git log --oneline origin/main..HEAD        # non-empty = drift, wrong base
+```
+
+If there is drift or a non-main development branch exists, ask Thom which branch to target.
+
 **When ready to push:**
 
 1. `git push origin <branch>`

--- a/doc/prompts/agent-merlin.md
+++ b/doc/prompts/agent-merlin.md
@@ -54,19 +54,12 @@ git -C /projects/<repo> worktree add /projects/scratchpad/<repo>-<name-mmm-dd> -
 
 Reuse an existing worktree if it's on the right branch. Use plain git commits in the worktree.
 
-**Before opening a PR:** repos managed with jj may have a development branch (e.g. `0.3.0`) that is ahead of `origin/main` and never merged back yet. Never assume `main` is the right PR base. Always verify first:
-
-```bash
-git -C /projects/<repo> branch -r          # see what remote branches exist
-git log --oneline origin/main..HEAD        # non-empty = drift, wrong base
-```
-
-If there is drift or a non-main development branch exists, ask Thom which branch to target.
-
 **When ready to push:**
 
 1. `git push origin <branch>`
 2. `gh pr create --head <branch> --base main --title "type(scope): message" --body "..."`
+
+> **Never push directly to `main`** (e.g. `git push origin HEAD:main`). Always go through a PR.
 
 **When work is done:** clean up the worktree after the PR is open.
 

--- a/doc/prompts/agent-merlin.md
+++ b/doc/prompts/agent-merlin.md
@@ -132,8 +132,8 @@ Rook2 is a code reviewer agent. When invoking Rook2, always provide:
 | ------------------------------------- | ---------------------------------------- |
 | the first commit is made              | push and open PR                         |
 | commit                                | push                                     |
-| thom leaves review comments in github | pull the comments and work on them       |
-| github comments are addressed         | close the comments using the graphql API |
+| thom leaves review comments in github | fetch inline diff comments via `gh api repos/rthomazel/{repo}/pulls/{n}/comments`, work on each one |
+| github comments are addressed         | resolve each thread via GraphQL `resolveReviewThread` mutation                                       |
 
 # Final word
 


### PR DESCRIPTION
When a repo is managed locally with jj, `origin/main` may be far behind the local working branch (e.g. `0.3.0`). Creating a worktree from local HEAD and opening a PR against `main` silently includes all that extra history.

Add a note to the VCS workflow section of `agent-merlin.md` to always check for remote branches and commit drift before opening a PR, and to ask Thom for the right target branch if in doubt.