### PR TITLE
fix(mise): switch shfmt backend from aqua to asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.26.3
 oxfmt latest
 shellcheck 0.11.0
-shfmt      3.13.1
+asdf:luizm/asdf-shfmt 3.13.1
 gh latest

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -13,31 +13,38 @@ Host repos are mounted read-only at `/projects/<repo>` — use them for reading 
 For any change, clone to scratchpad:
 
 ```bash
-git clone git@github.com:rthomazel/<repo>.git /projects/scratchpad/<repo>-<purpose-mmm-dd>
+git clone git@github.com:<org>/<repo>.git /projects/scratchpad/<repo>-<purpose-mmm-dd>
 cd /projects/scratchpad/<repo>-<purpose-mmm-dd>
+git config --local gpg.program /usr/local/bin/gpg-passphrase-wrapper
 git checkout -b <branch-name>
+```
+
+If the repo has a `bin/setup`, run it after cloning — it installs tools and configures GPG signing::
+
+```bash
+./bin/setup
 ```
 
 ### Repo Catalog
 
-| Mount                | Clone URL                                                      |
+| Mount                | Clone URL                                           |
 | -------------------- | --------------------------------------------------- |
-| server               | `git@github.com:eleanorhealth/hub-server.git`                  |
-| member-server        | `git@github.com:eleanorhealth/member-server.git`               |
+| server               | `git@github.com:eleanorhealth/hub-server.git`       |
+| member-server        | `git@github.com:eleanorhealth/member-server.git`    |
 | interface            | `git@github.com:rthomazel/interface.git`            |
-| client               | `git@github.com:eleanorhealth/hub-client.git`                  |
-| comms                | `git@github.com:eleanorhealth/comms.git`                       |
-| go                   | `git@github.com:tcodes0/go.git`                                |
-| go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`             |
-| go-common            | `git@github.com:eleanorhealth/go-common.git`                   |
+| client               | `git@github.com:eleanorhealth/hub-client.git`       |
+| comms                | `git@github.com:eleanorhealth/comms.git`            |
+| go                   | `git@github.com:tcodes0/go.git`                     |
+| go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`  |
+| go-common            | `git@github.com:eleanorhealth/go-common.git`        |
 | jail-mcp             | `git@github.com:rthomazel/jail-mcp.git`             |
-| member-client        | `git@github.com:eleanorhealth/member-client.git`               |
-| scheduling           | `git@github.com:eleanorhealth/scheduling.git`                  |
-| shared               | `git@github.com:eleanorhealth/frontend-shared.git`             |
+| member-client        | `git@github.com:eleanorhealth/member-client.git`    |
+| scheduling           | `git@github.com:eleanorhealth/scheduling.git`       |
+| shared               | `git@github.com:eleanorhealth/frontend-shared.git`  |
 | compose-files        | `git@github.com:rthomazel/compose-files.git`        |
-| feature-flag         | `git@github.com:eleanorhealth/feature-flag.git`                |
+| feature-flag         | `git@github.com:eleanorhealth/feature-flag.git`     |
 | programming-problems | `git@github.com:rthomazel/programming-problems.git` |
-| wiki                 | `https://github.com/rthomazel/rthomazel.wiki.git`              |
+| wiki                 | `https://github.com/rthomazel/rthomazel.wiki.git`   |
 
 ## Pushing & PRs
 


### PR DESCRIPTION
The `aqua:mvdan/sh` backend expects a `sha256sums.txt` asset in the shfmt GitHub release, which does not exist in v3.13.1 (or any version). This causes `bin/setup` to fail partway through, which means GPG signing setup is skipped and commits from fresh clones will fail to sign.

Switch to `asdf:luizm/asdf-shfmt` which downloads the binary directly from the release URL.