### PR TITLE
docs(github-skill): prefer setup MCP tool over running bin/setup directly

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.26.3
 oxfmt latest
 shellcheck 0.11.0
-shfmt      3.13.1
+asdf:luizm/asdf-shfmt 3.13.1
 gh latest

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -19,11 +19,13 @@ git config --local gpg.program /usr/local/bin/gpg-passphrase-wrapper
 git checkout -b <branch-name>
 ```
 
-If the repo has a `bin/setup`, run it after cloning — it installs tools and configures GPG signing::
+After cloning, always run the `setup` MCP tool — it installs tool versions and dependencies via mise, and runs `bin/setup` if present (which configures GPG signing and other repo-specific setup). Report any errors to Thom.
 
-```bash
-./bin/setup
 ```
+setup(["path/to/clone"])
+```
+
+Only run `./bin/setup` directly if the MCP tool is unavailable.
 
 ### Repo Catalog
 
@@ -54,6 +56,8 @@ If the repo has a `bin/setup`, run it after cloning — it installs tools and co
 2. `gh pr create --head <branch> --base main --title "type(scope): message" --body "..."`
 
 > **Never push directly to `main`**. Always go through a PR.
+
+> **Never force push** (`--force` or `--force-with-lease`) to a branch. If a push is rejected, investigate why rather than forcing.
 
 **After the PR is merged:** delete the clone.
 

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -57,7 +57,7 @@ Only run `./bin/setup` directly if the MCP tool is unavailable.
 
 > **Never push directly to `main`**. Always go through a PR.
 
-> **Never force push** (`--force` or `--force-with-lease`) to a branch. If a push is rejected, investigate why rather than forcing.
+> **Avoid force pushing.** Prefer adding a new commit over amending and force pushing — amends lose history. Force pushing is acceptable for clean-up amends on your own branch, but never on `main`.
 
 **After the PR is merged:** delete the clone.
 

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -13,31 +13,38 @@ Host repos are mounted read-only at `/projects/<repo>` — use them for reading 
 For any change, clone to scratchpad:
 
 ```bash
-git clone git@github.com:rthomazel/<repo>.git /projects/scratchpad/<repo>-<purpose-mmm-dd>
+git clone git@github.com:<org>/<repo>.git /projects/scratchpad/<repo>-<purpose-mmm-dd>
 cd /projects/scratchpad/<repo>-<purpose-mmm-dd>
+git config --local gpg.program /usr/local/bin/gpg-passphrase-wrapper
 git checkout -b <branch-name>
+```
+
+If the repo has a `bin/setup`, run it after cloning — it installs tools and configures GPG signing::
+
+```bash
+./bin/setup
 ```
 
 ### Repo Catalog
 
-| Mount                | Clone URL                                                      |
+| Mount                | Clone URL                                           |
 | -------------------- | --------------------------------------------------- |
-| server               | `git@github.com:eleanorhealth/hub-server.git`                  |
-| member-server        | `git@github.com:eleanorhealth/member-server.git`               |
+| server               | `git@github.com:eleanorhealth/hub-server.git`       |
+| member-server        | `git@github.com:eleanorhealth/member-server.git`    |
 | interface            | `git@github.com:rthomazel/interface.git`            |
-| client               | `git@github.com:eleanorhealth/hub-client.git`                  |
-| comms                | `git@github.com:eleanorhealth/comms.git`                       |
-| go                   | `git@github.com:tcodes0/go.git`                                |
-| go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`             |
-| go-common            | `git@github.com:eleanorhealth/go-common.git`                   |
+| client               | `git@github.com:eleanorhealth/hub-client.git`       |
+| comms                | `git@github.com:eleanorhealth/comms.git`            |
+| go                   | `git@github.com:tcodes0/go.git`                     |
+| go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`  |
+| go-common            | `git@github.com:eleanorhealth/go-common.git`        |
 | jail-mcp             | `git@github.com:rthomazel/jail-mcp.git`             |
-| member-client        | `git@github.com:eleanorhealth/member-client.git`               |
-| scheduling           | `git@github.com:eleanorhealth/scheduling.git`                  |
-| shared               | `git@github.com:eleanorhealth/frontend-shared.git`             |
+| member-client        | `git@github.com:eleanorhealth/member-client.git`    |
+| scheduling           | `git@github.com:eleanorhealth/scheduling.git`       |
+| shared               | `git@github.com:eleanorhealth/frontend-shared.git`  |
 | compose-files        | `git@github.com:rthomazel/compose-files.git`        |
-| feature-flag         | `git@github.com:eleanorhealth/feature-flag.git`                |
+| feature-flag         | `git@github.com:eleanorhealth/feature-flag.git`     |
 | programming-problems | `git@github.com:rthomazel/programming-problems.git` |
-| wiki                 | `https://github.com/rthomazel/rthomazel.wiki.git`              |
+| wiki                 | `https://github.com/rthomazel/rthomazel.wiki.git`   |
 
 ## Pushing & PRs
 


### PR DESCRIPTION
Clarifies that after cloning, the `setup` MCP tool should be used instead of running `./bin/setup` manually. The tool runs the script and surfaces errors, and is the established pattern for all other repos at session start.