### PR TITLE
docs(github-skill): require signed commits, report failures to Thom

### DIFF
--- a/doc/ideas/aichat/issues.md
+++ b/doc/ideas/aichat/issues.md
@@ -4,6 +4,13 @@
 
 ## patched and testing
 
+### Message nav scrub bar — patch 019
+
+The indicator buttons in `MessageNav.tsx` had a click target of `h-[5px]` (5 px) — pixel-perfect
+clicks required. Fixed by bumping the button to `h-3` (12 px), a 2.4× larger hit area. The visual
+inner span keeps its original dimensions so appearance is unchanged. Column gap tightened from
+`gap-1.5` to `gap-0.5` to compensate for the taller buttons and keep the nav height roughly the same.
+
 ### Last thought always open — patch 017 v2
 
 v1 kept thoughts open when followed by a tool call (`nextType === TOOL_CALL`). This caused

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -25,6 +25,8 @@ If the repo has a `bin/setup`, run it after cloning — it installs tools and co
 ./bin/setup
 ```
 
+All commits must be signed. If signing fails or GPG behaves unexpectedly, report it to Thom before continuing.
+
 ### Repo Catalog
 
 | Mount                | Clone URL                                           |


### PR DESCRIPTION
Adds an explicit policy line to the Clone Workflow section: all commits must be signed, and any GPG failures should be reported to Thom before continuing.