### PR TITLE
feat(skills): add lga-patching skill

### DIFF
--- a/doc/ideas/lga/librechat-issues.md
+++ b/doc/ideas/lga/librechat-issues.md
@@ -4,6 +4,31 @@
 
 ## patched and testing
 
+### Search sidebar filtered by matching conversations — patch 020 v2
+
+v1 fixed the blank sidebar by removing the broken title-search param. v2 goes further:
+when a search is active the sidebar now shows **only the conversations that contain a
+matching message**, derived from the same `useMessagesInfiniteQuery` call already made
+by the right-pane `Search.tsx`. React Query deduplicates the request — zero extra
+network cost. Conversations with no matching messages are hidden during search.
+
+Known limitation: archived conversations are excluded because `useConversationsInfiniteQuery`
+does not return them. Full archived support would require a separate fetch.
+
+### Meilisearch bulk sync misses agent messages — patch 021
+
+All agent messages have `text: ""` — their content lives in `content[]` typed parts
+(`type: text`, `type: think`, `type: tool_call`). The per-save Mongoose hook
+(`preprocessObjectForIndex`) already calls `parseTextParts(content)` correctly.
+But `processSyncBatch` (bulk sync path) does `_.pick(doc, attributesToIndex)` —
+`content` is not in `attributesToIndex`, so every agent message was indexed with
+empty text after any bulk re-index (Meilisearch wipe, restart, etc.).
+
+Fix: add `content` to the `.select()` in `syncWithMeili`; in `processSyncBatch`
+apply `parseTextParts(doc.content)` when `text` is empty. `parseTextParts`
+includes TEXT + THINK parts and skips TOOL_CALL by design.
+
+
 ### summarization
 
 The chat appears to be stuck. There is indication of work. The stop button in the input. There is a spinner. But there is no summarization copy visible anywhere.

--- a/doc/ideas/lga/librechat-issues.md
+++ b/doc/ideas/lga/librechat-issues.md
@@ -4,16 +4,20 @@
 
 ## patched and testing
 
-### Search sidebar filtered by matching conversations — patch 020 v2
+### Search sidebar shows matching conversations incl. archived — patch 020 v3
 
-v1 fixed the blank sidebar by removing the broken title-search param. v2 goes further:
-when a search is active the sidebar now shows **only the conversations that contain a
-matching message**, derived from the same `useMessagesInfiniteQuery` call already made
-by the right-pane `Search.tsx`. React Query deduplicates the request — zero extra
-network cost. Conversations with no matching messages are hidden during search.
+v1 fixed the blank sidebar. v2 filtered to conversations with matching messages.
+v3 adds archived conversations to the mix:
 
-Known limitation: archived conversations are excluded because `useConversationsInfiniteQuery`
-does not return them. Full archived support would require a separate fetch.
+- `ConversationsSection` fires a second `useConversationsInfiniteQuery({ isArchived: true })`
+  only while search is active — zero cost in normal use.
+- Both lists are merged and filtered by the matching `conversationId` set from
+  `useMessagesInfiniteQuery` (React Query deduplicates that call with `Search.tsx`).
+- `Convo.tsx`: when `conversation.isArchived === true`, the endpoint/model icon is
+  replaced with a `<Archive>` lucide icon so archived rows are visually distinct.
+
+Known limitation: the sidebar only loads one page of archived conversations. Deep
+archives with hundreds of entries may miss results beyond page 1.
 
 ### Meilisearch bulk sync misses agent messages — patch 021
 

--- a/doc/skills/ai-chat-search.md
+++ b/doc/skills/ai-chat-search.md
@@ -14,14 +14,14 @@ description: Use when the user mentions search not working, wants to inspect or 
 5. Results carry `conversationId`; backend calls `db.getConvosQueried(userId, hits)` to enrich each hit with `title`, `model`, etc.
 6. Right pane renders the enriched message hits via `SearchMessage` components
 
-**The sidebar** (`ConversationsSection`) is independent — it always shows all conversations. It does NOT participate in search filtering (patch 020 removed the broken `search` param that was blanking it).
+**The sidebar** (`ConversationsSection`) is independent — it always shows all conversations. When search is active it shows **only conversations with matching messages** (patch 020 v2), derived from the same message search query — zero extra network cost.
 
 ## Two separate search endpoints
 
 | Endpoint | What it searches | Used by |
 |---|---|---|
 | `GET /api/messages?search=` | Meilisearch `messages` index (full-text) | Search route right pane |
-| `GET /api/convos?search=` | MongoDB title match | Was incorrectly used by sidebar (patch 020 removed) |
+| `GET /api/convos?search=` | MongoDB title match | Not used for sidebar — title search is useless for message content |
 
 Conversation title search is essentially useless for message retrieval — never pass `search` to the convos endpoint for the sidebar.
 

--- a/doc/skills/chatui-patching.md
+++ b/doc/skills/chatui-patching.md
@@ -1,5 +1,5 @@
 ---
-name: lga-patching
+name: chatui-patching
 description: Use when writing, fixing, or validating LibreChat patches for the LGA project, or when working on files under images/librechat/patches/.
 ---
 

--- a/doc/skills/chatui-patching.md
+++ b/doc/skills/chatui-patching.md
@@ -10,12 +10,12 @@ Clone URL: `git@github.com:rthomazel/lga.git`
 
 ## Paths
 
-| What | Where |
-| ---- | ----- |
-| Patch files | `images/librechat/patches/NNN-*.diff` |
-| Patching docs | `doc/patching-librechat.md` |
+| What            | Where                                                            |
+| --------------- | ---------------------------------------------------------------- |
+| Patch files     | `images/librechat/patches/NNN-*.diff`                            |
+| Patching docs   | `doc/patching-librechat.md`                                      |
 | TSC environment | `/projects/scratchpad/librechat-tsc` (persistent, do not delete) |
-| Upgrade script | `bin/upgrade-chatui` |
+| Upgrade script  | `bin/upgrade-chatui`                                             |
 
 The TSC environment is a pinned clone of LibreChat at the current `LIBRECHAT_VERSION` (see `compose.yml`) with `node_modules` already installed. Rebuilding it takes ~5 min.
 

--- a/doc/skills/lga-patching.md
+++ b/doc/skills/lga-patching.md
@@ -1,0 +1,139 @@
+---
+name: lga-patching
+description: Use when writing, fixing, or validating LibreChat patches for the LGA project, or when working on files under images/librechat/patches/.
+---
+
+# LGA — LibreChat Patch Workflow
+
+Patches live in the `lga` repo at `images/librechat/patches/`.
+Clone URL: `git@github.com:rthomazel/lga.git`
+
+## Paths
+
+| What | Where |
+| ---- | ----- |
+| Patch files | `images/librechat/patches/NNN-*.diff` |
+| Patching docs | `doc/patching-librechat.md` |
+| TSC environment | `/projects/scratchpad/librechat-tsc` (persistent, do not delete) |
+| Upgrade script | `bin/upgrade-chatui` |
+
+The TSC environment is a pinned clone of LibreChat at the current `LIBRECHAT_VERSION` (see `compose.yml`) with `node_modules` already installed. Rebuilding it takes ~5 min.
+
+## Mandatory Validation After Every Patch Write or Fix
+
+Always run both checks before committing.
+
+### 1 — Full sequence apply check
+
+Reset the TSC clone, then apply every patch in order:
+
+```bash
+git -C /projects/scratchpad/librechat-tsc checkout -- .
+for p in $(ls /path/to/lga-clone/images/librechat/patches/*.diff | sort); do
+  printf '%%-70s ' "$(basename $p)"
+  patch -p1 -d /projects/scratchpad/librechat-tsc < $p && echo CLEAN || echo FAILED
+done
+```
+
+Every patch must print `CLEAN`. A `FAILED` means the patch itself or its hunk header (line count / offset) is wrong.
+
+### 2 — TSC check on touched files
+
+Filter by the filename(s) you changed — ~152 pre-existing upstream errors exist in unrelated files; ignore those.
+
+```bash
+cd /projects/scratchpad/librechat-tsc
+npx tsc --noEmit -p client/tsconfig.json 2>&1 | grep 'error TS' | grep -E 'File1|File2'
+```
+
+No output = clean. Any output means the patch introduces a type error.
+
+## Writing a New Patch
+
+### 1. Reset and save the original
+
+```bash
+git -C /projects/scratchpad/librechat-tsc checkout -- .
+cp /projects/scratchpad/librechat-tsc/client/src/path/to/File.tsx /tmp/File.orig.tsx
+```
+
+### 2. Edit the target file
+
+Edit directly in `/projects/scratchpad/librechat-tsc/`.
+
+### 3. Run mandatory validation (see above)
+
+TSC-check before generating the diff.
+
+### 4. Generate the diff
+
+```bash
+diff -u \
+  --label a/client/src/path/to/File.tsx \
+  --label b/client/src/path/to/File.tsx \
+  /tmp/File.orig.tsx \
+  /projects/scratchpad/librechat-tsc/client/src/path/to/File.tsx \
+  > images/librechat/patches/NNN-description--path-File.diff
+```
+
+Multi-file patch: concatenate with `>>`.
+
+### 5. Run mandatory validation again on the full sequence
+
+After the diff is on disk, reset the TSC clone and run the full sequence check.
+
+## Fixing a Broken Patch
+
+1. Apply all patches **up to but not including** the broken one to see the actual source state
+2. Read `patch` stderr and any `.rej` files in the TSC clone — they show what context didn't match
+3. Correct the hunk header counts in `@@ -old,n +new,n @@` and/or surrounding context lines
+4. Run the full sequence check to confirm
+
+Common cause: a hunk line count is off by one because the added `+` or removed `-` lines don't add up to the number in `@@ -old,n +new,n @@`.
+
+## Patch Conventions
+
+- Naming: `NNN-short-description--Source-File-ComponentName.diff` (NNN zero-padded)
+- Format: unified diff, `-p1` (paths relative to repo root)
+- Applied in filename sort order — if patch B depends on A, A must have a lower number
+- Multi-file patches concatenate multiple `diff -u` outputs into one file
+
+## JSX Gotcha — Ternaries Inside Expression Context
+
+In the second arm of a JSX ternary (inside `( ... )`), curly braces `{ }` are a JS
+**object literal**, not a JSX expression block. If you need a nested conditional there,
+use a bare ternary — no wrapping `{ }`:
+
+```jsx
+// Wrong — {} is an object literal, esbuild errors:
+) : (
+  {condition ? <A /> : <B />}
+)}
+
+// Correct — bare ternary:
+) : (
+  condition ? <A /> : <B />
+)}
+```
+
+The hunk header line count must reflect the actual number of `+` / `-` lines.
+
+## Rebuilding After a Patch Change
+
+Always use `--no-cache` — Docker caches the patch layer by content hash.
+
+```bash
+cd ~/Desktop/lga
+docker compose build --no-cache api
+docker compose up -d api
+```
+
+## Upgrading LibreChat
+
+```bash
+cd ~/Desktop/lga
+./bin/upgrade-chatui <new-version>           # verify only
+./bin/upgrade-chatui <new-version> --build   # verify + rebuild
+```
+
+See `doc/patching-librechat.md` for the full upgrade procedure and fuzz details.


### PR DESCRIPTION
Adapts `doc/patching-librechat.md` into a callable agent skill.

**Motivation:** patches 020/021 were written without running the mandatory validation sequence, resulting in a broken hunk header and a JSX syntax error in the Docker build. A dedicated skill gives the agent a reliable checklist to invoke any time it touches `images/librechat/patches/`.

**Skill covers:**
- Mandatory post-write validation: full sequence apply check + TSC check on touched files
- Step-by-step patch authoring workflow
- How to diagnose and fix broken hunks
- Patch naming conventions
- JSX ternary-in-expression-context gotcha (the specific bug from patch 020)
- Rebuilding and upgrading