### PR TITLE
feat(src/compose-setup): add git_hook_commit part

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -66,8 +66,30 @@ run_permissions() {
   chmod u+x "$script_dir/../run" "$script_dir/setup" 2>/dev/null || true
 }
 
+# shellcheck shell=bash
+# Installs a post-commit git hook that prints agent reminders after each commit.
+git_hook_post_commit() {
+  local hooks_dir="$SCRIPT_DIR/../.git/hooks"
+
+  if [[ ! -d "$hooks_dir" ]]; then
+    echo "bin/setup: .git/hooks not found, skipping hook install" >&2
+    return 0
+  fi
+
+  cat >"$hooks_dir/post-commit" <<'HOOK'
+#!/usr/bin/env bash
+# post-commit — agent reminders
+
+printf 'reminder: Refer to project instructions on what needs to happen on commit.\n'
+HOOK
+
+  chmod +x "$hooks_dir/post-commit"
+  echo "bin/setup: post-commit hook installed"
+}
+
 toolchain
 commit_signing
 run_permissions
+git_hook_post_commit
 
 echo "setup complete"

--- a/bin/setup
+++ b/bin/setup
@@ -69,7 +69,9 @@ run_permissions() {
 # shellcheck shell=bash
 # Installs a post-commit git hook that prints agent reminders after each commit.
 git_hook_post_commit() {
-  local hooks_dir="$SCRIPT_DIR/../.git/hooks"
+  local script_dir hooks_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  hooks_dir="$script_dir/../.git/hooks"
 
   if [[ ! -d "$hooks_dir" ]]; then
     echo "bin/setup: .git/hooks not found, skipping hook install" >&2

--- a/doc/agents/merlin.md
+++ b/doc/agents/merlin.md
@@ -1,7 +1,7 @@
 # Basics
 
-Use exec_sync for most file tasks (cat, find, grep). This is the only way to interact with project files.
-Use exec_background for slow commands; poll with the status tool. You can do other work while waiting.
+Use `shell` for most file tasks (cat, find, grep). This is the only way to interact with project files.
+Use `shell_background` for slow commands; poll with the status tool. You can do other work while waiting.
 Go projects may have private dependencies, go mod download without setup will fail — the setup tool runs bin/setup to set GOPRIVATE.
 
 Editing files:

--- a/doc/agents/wren.md
+++ b/doc/agents/wren.md
@@ -19,10 +19,10 @@ Your job is to go in, do the work cleanly, and come back with clear findings.
 
 ## Running Commands
 
-Use `exec_sync` for most tasks: reading files, searching, grepping, running quick commands.
-Use `exec_background` for slow commands (builds, tests, installs) — poll with the status tool.
+Use `shell` for most tasks: reading files, searching, grepping, running quick commands.
+Use `shell_background` for slow commands (builds, tests, installs) — poll with the status tool.
 You can do other work while a background job runs. Do not block on it unnecessarily.
-Commands time out after 15s (exec_sync) and 5m (exec_background).
+Commands time out after 15s (`shell`) and 5m (`shell_background`).
 
 ## Reading Files
 

--- a/doc/ideas/inbox/misc.md
+++ b/doc/ideas/inbox/misc.md
@@ -41,3 +41,4 @@
 - [ ] diff-to-html: a skill/tool/script that receives a unified diff as input and renders it as formatted HTML (syntax-highlighted, red/green lines), so it can be dropped directly into an artifact
 - [ ] jail mcp: Start collecting data on which tools are called with which arguments and dump it on an SQLite file for analysis later. do clever statistics with it.
 - [ ] refactor interface bash scripts take a look at bash env and lib.sh and make the whole thing less magical.
+- [ ] secret server needs a backup routine to my google drive or something

--- a/doc/skills/chatui-skills.md
+++ b/doc/skills/chatui-skills.md
@@ -112,6 +112,34 @@ always-apply: true
 # Skill body here
 ```
 
+## Syncing a Skill Body
+
+> **`body`, not `content`.** The field is `body`. The agent sync example in `chatui` uses a Python variable named `content` — do not carry that over. Writing to `content` silently creates a stale orphan field and the skill will not update in the UI.
+
+```bash
+PYTHONPATH=/root/pylib python3 << 'PYEOF'
+from pymongo import MongoClient
+from datetime import datetime, timezone
+db = MongoClient('mongodb', 27017)['LibreChat']
+body = open('/projects/interface/doc/skills/<name>.md').read()
+result = db.skills.update_one(
+    {'name': '<skill-name>'},
+    {'$set': {'body': body, 'updatedAt': datetime.now(timezone.utc)}, '$inc': {'version': 1}}
+)
+print(f'matched: {result.matched_count}, modified: {result.modified_count}')
+PYEOF
+```
+
+If a stale `content` field was previously written, remove it:
+
+```bash
+PYTHONPATH=/root/pylib python3 << 'PYEOF'
+from pymongo import MongoClient
+db = MongoClient('mongodb', 27017)['LibreChat']
+db.skills.update_one({'name': '<skill-name>'}, {'$unset': {'content': ''}})
+PYEOF
+```
+
 ## Inspecting a Skill
 
 ```javascript

--- a/doc/skills/chatui.md
+++ b/doc/skills/chatui.md
@@ -45,7 +45,7 @@ No authentication. Key collections:
 
 Source files live at `/projects/interface/doc/agents/*.md`. Skill definitions live at `/projects/interface/doc/skills/*.md`.
 
-Sync a prompt file to its agent database record after editing:
+Sync a prompt file to its agent database record after editing. Note: the Python variable here is named `content` for readability — agents use the `instructions` field. **For skills the field is `body`** — see `chatui-skills` for the correct skill sync pattern.
 
 ```bash
 PYTHONPATH=/root/pylib python3 << 'PYEOF'

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -41,7 +41,7 @@ All commits must be signed. If signing fails or GPG behaves unexpectedly, report
 | go                   | `git@github.com:tcodes0/go.git`                     |
 | go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`  |
 | go-common            | `git@github.com:eleanorhealth/go-common.git`        |
-| jail-mcp             | `git@github.com:rthomazel/jail-mcp.git`             |
+| bench-mcp            | `git@github.com:rthomazel/bench-mcp.git`            |
 | member-client        | `git@github.com:eleanorhealth/member-client.git`    |
 | scheduling           | `git@github.com:eleanorhealth/scheduling.git`       |
 | shared               | `git@github.com:eleanorhealth/frontend-shared.git`  |

--- a/dotfiles/.aliases.sh
+++ b/dotfiles/.aliases.sh
@@ -242,7 +242,7 @@ alias m-="lg misc - misc"
 
 # jujutsu
 alias j="jj"
-alias jgp="jj git push --option quiet"
+alias jgp="jj git push --quiet"
 alias jgf="jj git fetch"
 alias jsq="jj squash"
 alias jre="jj resolve"

--- a/dotfiles/.config/github.com.rthomazel/.composeagentsmdrc
+++ b/dotfiles/.config/github.com.rthomazel/.composeagentsmdrc
@@ -24,6 +24,6 @@ lga:             role commits
 
 # Unmanaged projects (AGENTS.md too unique for common fragments):
 # interface         -- shell-specific role and style
-# jail-mcp         -- different document structure
+# bench-mcp         -- different document structure
 # programming-problems -- entirely different purpose
 # scratchpad       -- freeform, project-specific

--- a/dotfiles/.config/github.com.rthomazel/.composesetuprc
+++ b/dotfiles/.config/github.com.rthomazel/.composesetuprc
@@ -9,7 +9,7 @@ compose-files:   toolchain commit_signing env_file run_permissions
 go:              toolchain commit_signing go_download run_permissions
 go-athenahealth: toolchain commit_signing go_download
 go-common:       toolchain commit_signing env_file eleanor_go_download
-jail-mcp:        toolchain commit_signing run_permissions git_hook_post_commit
+bench-mcp:       toolchain commit_signing run_permissions git_hook_post_commit
 member-client:   toolchain commit_signing env_file eleanor_node_download
 member-server:   toolchain commit_signing env_file eleanor_go_download
 scheduling:      toolchain commit_signing env_file eleanor_go_download

--- a/dotfiles/.config/github.com.rthomazel/.composesetuprc
+++ b/dotfiles/.config/github.com.rthomazel/.composesetuprc
@@ -9,11 +9,11 @@ compose-files:   toolchain commit_signing env_file run_permissions
 go:              toolchain commit_signing go_download run_permissions
 go-athenahealth: toolchain commit_signing go_download
 go-common:       toolchain commit_signing env_file eleanor_go_download
-jail-mcp:        toolchain commit_signing run_permissions
+jail-mcp:        toolchain commit_signing run_permissions git_hook_post_commit
 member-client:   toolchain commit_signing env_file eleanor_node_download
 member-server:   toolchain commit_signing env_file eleanor_go_download
 scheduling:      toolchain commit_signing env_file eleanor_go_download
 server:          toolchain commit_signing env_file eleanor_go_download run_permissions
 shared:          toolchain commit_signing js_install
-interface:       toolchain commit_signing run_permissions
-lga:             toolchain commit_signing env_file run_permissions
+interface:       toolchain commit_signing run_permissions git_hook_post_commit
+lga:             toolchain commit_signing env_file run_permissions git_hook_post_commit

--- a/dotfiles/.config/github.com.rthomazel/.composetoolversionrc
+++ b/dotfiles/.config/github.com.rthomazel/.composetoolversionrc
@@ -11,7 +11,7 @@ member-server:    golang oxfmt gh
 go-common:        golang oxfmt gh
 go-athenahealth:  golang oxfmt gh
 go:               golang oxfmt gh
-jail-mcp:         golang oxfmt gh
+bench-mcp:        golang oxfmt gh
 feature-flag:     golang oxfmt gh
 
 # mixed / infra

--- a/dotfiles/.config/github.com.rthomazel/.pushrc
+++ b/dotfiles/.config/github.com.rthomazel/.pushrc
@@ -11,7 +11,7 @@ member-server
 shared
 go-athenahealth
 scheduling
-jail-mcp
+bench-mcp
 comms
 programming-problems
 online-start

--- a/src/compose-agents-md/README.md
+++ b/src/compose-agents-md/README.md
@@ -69,7 +69,7 @@ Oxfmt is used
 Some projects have `AGENTS.md` files too unique to assemble from common fragments:
 
 - `interface` — shell-specific role and style
-- `jail-mcp` — different document structure
+- `bench-mcp` — different document structure
 - `scratchpad` — project-specific freeform
 - `programming-problems` — entirely different purpose
 

--- a/src/compose-setup/git_hook_commit.sh
+++ b/src/compose-setup/git_hook_commit.sh
@@ -1,0 +1,22 @@
+# shellcheck shell=bash
+# Installs a post-commit git hook that prints agent reminders after each commit.
+git_hook_commit() {
+  local hooks_dir="$SCRIPT_DIR/../.git/hooks"
+
+  if [[ ! -d "$hooks_dir" ]]; then
+    echo "bin/setup: .git/hooks not found, skipping hook install" >&2
+    return 0
+  fi
+
+  cat >"$hooks_dir/post-commit" <<'HOOK'
+#!/usr/bin/env bash
+# post-commit — agent reminders
+
+printf '\n=== post-commit reminder ===\n'
+printf 'TODO: placeholder — add agent reminders here\n'
+printf '============================\n\n'
+HOOK
+
+  chmod +x "$hooks_dir/post-commit"
+  echo "bin/setup: post-commit hook installed"
+}

--- a/src/compose-setup/git_hook_post_commit.sh
+++ b/src/compose-setup/git_hook_post_commit.sh
@@ -1,7 +1,9 @@
 # shellcheck shell=bash
 # Installs a post-commit git hook that prints agent reminders after each commit.
 git_hook_post_commit() {
-  local hooks_dir="$SCRIPT_DIR/../.git/hooks"
+  local script_dir hooks_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  hooks_dir="$script_dir/../.git/hooks"
 
   if [[ ! -d "$hooks_dir" ]]; then
     echo "bin/setup: .git/hooks not found, skipping hook install" >&2

--- a/src/compose-setup/git_hook_post_commit.sh
+++ b/src/compose-setup/git_hook_post_commit.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 # Installs a post-commit git hook that prints agent reminders after each commit.
-git_hook_commit() {
+git_hook_post_commit() {
   local hooks_dir="$SCRIPT_DIR/../.git/hooks"
 
   if [[ ! -d "$hooks_dir" ]]; then
@@ -12,9 +12,7 @@ git_hook_commit() {
 #!/usr/bin/env bash
 # post-commit — agent reminders
 
-printf '\n=== post-commit reminder ===\n'
-printf 'TODO: placeholder — add agent reminders here\n'
-printf '============================\n\n'
+printf 'reminder: Refer to project instructions on what needs to happen on commit.\n'
 HOOK
 
   chmod +x "$hooks_dir/post-commit"


### PR DESCRIPTION
Adds a new `git_hook_commit` function fragment to `src/compose-setup/`.

When included in a project via `.composesetuprc`, running `bin/setup` installs a `post-commit` git hook that prints a reminder message after each commit. The message content is a placeholder for now.

- Gracefully skips if `.git/hooks` does not exist
- Hook is `chmod +x` on install
- Lint and format clean