### PR TITLE
refactor: jail-mcp → bench-mcp, exec_sync/exec_background → shell/shell_background

### DIFF
--- a/doc/agents/wren.md
+++ b/doc/agents/wren.md
@@ -19,10 +19,10 @@ Your job is to go in, do the work cleanly, and come back with clear findings.
 
 ## Running Commands
 
-Use `exec_sync` for most tasks: reading files, searching, grepping, running quick commands.
-Use `exec_background` for slow commands (builds, tests, installs) — poll with the status tool.
+Use `shell` for most tasks: reading files, searching, grepping, running quick commands.
+Use `shell_background` for slow commands (builds, tests, installs) — poll with the status tool.
 You can do other work while a background job runs. Do not block on it unnecessarily.
-Commands time out after 15s (exec_sync) and 5m (exec_background).
+Commands time out after 15s (`shell`) and 5m (`shell_background`).
 
 ## Reading Files
 

--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -41,7 +41,7 @@ All commits must be signed. If signing fails or GPG behaves unexpectedly, report
 | go                   | `git@github.com:tcodes0/go.git`                     |
 | go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`  |
 | go-common            | `git@github.com:eleanorhealth/go-common.git`        |
-| jail-mcp             | `git@github.com:rthomazel/jail-mcp.git`             |
+| bench-mcp            | `git@github.com:rthomazel/bench-mcp.git`            |
 | member-client        | `git@github.com:eleanorhealth/member-client.git`    |
 | scheduling           | `git@github.com:eleanorhealth/scheduling.git`       |
 | shared               | `git@github.com:eleanorhealth/frontend-shared.git`  |

--- a/src/compose-agents-md/README.md
+++ b/src/compose-agents-md/README.md
@@ -69,7 +69,7 @@ Oxfmt is used
 Some projects have `AGENTS.md` files too unique to assemble from common fragments:
 
 - `interface` — shell-specific role and style
-- `jail-mcp` — different document structure
+- `bench-mcp` — different document structure
 - `scratchpad` — project-specific freeform
 - `programming-problems` — entirely different purpose
 


### PR DESCRIPTION
Updates all stale references across agent prompts, skills, and docs:

- `doc/agents/wren.md` — `exec_sync` → `shell`, `exec_background` → `shell_background`
- `doc/skills/github.md` — repo catalog `jail-mcp` → `bench-mcp` (clone URL updated for renamed repo)
- `src/compose-agents-md/README.md` — `jail-mcp` → `bench-mcp`

DB synced: wren agent and github skill updated in MongoDB.