### PR TITLE
fix(skills/github): update bench-mcp clone URL to mcp after repo rename

### DIFF
--- a/doc/skills/github.md
+++ b/doc/skills/github.md
@@ -41,7 +41,7 @@ All commits must be signed. If signing fails or GPG behaves unexpectedly, report
 | go                   | `git@github.com:tcodes0/go.git`                     |
 | go-athenahealth      | `git@github.com:eleanorhealth/go-athenahealth.git`  |
 | go-common            | `git@github.com:eleanorhealth/go-common.git`        |
-| bench-mcp            | `git@github.com:rthomazel/bench-mcp.git`            |
+| mcp                  | `git@github.com:rthomazel/mcp.git`                  |
 | member-client        | `git@github.com:eleanorhealth/member-client.git`    |
 | scheduling           | `git@github.com:eleanorhealth/scheduling.git`       |
 | shared               | `git@github.com:eleanorhealth/frontend-shared.git`  |


### PR DESCRIPTION
Updates the Repo Catalog in the github skill to reflect the pending rename of `bench-mcp` → `mcp`.

Depends on: https://github.com/rthomazel/bench-mcp/pull/22