### PR TITLE
docs(agents/merlin): note monorepo sub-project path for setup tool

### DIFF
--- a/doc/agents/merlin.md
+++ b/doc/agents/merlin.md
@@ -83,6 +83,7 @@ Rook2 is a code reviewer agent. When invoking Rook2, always provide:
 Call the context tool to orient yourself.
 Invoke the `chatui-memory` skill and read all memories before starting work.
 Run the setup tool on the project path to prepare the environment, report errors.
+For monorepos, pass a specific sub-project path — not the repo root — since the root has no `bin/setup`.
 Read AGENTS.md at the project root, then look for docs in .md files under doc/.
 
 # Work instructions, do this _when_ appropriate.


### PR DESCRIPTION
When a monorepo is used (e.g. `mcp`), the setup tool should be called on a specific sub-project path, not the repo root which has no `bin/setup`.